### PR TITLE
Shapefile zip URL handling

### DIFF
--- a/apps/merge/README.md
+++ b/apps/merge/README.md
@@ -78,7 +78,7 @@ The stepper resets selection state between actions, and you can jump backward or
 
 ## Data loading tips
 
-- Upload local `.osm.pbf` / `.geojson` / `.json` files, or use **Open from URL** for hosted files (the host must allow browser downloads via CORS).
+- Upload local `.osm.pbf` / `.geojson` / `.json` / `.zip` (Shapefile) files, or use **Open from URL** for hosted files (the host must allow browser downloads via CORS).
 - Adjust the defaults in `src/settings.ts` if you want the app to reference local dev fixtures by URL.
 - Large extracts work best when the browser has several gigabytes of free memory; use the “Check system” dialog to see current limits.
 - Changes and temporary files never leave the browser unless you explicitly download them.

--- a/apps/merge/src/lib/fetch-osm-file.ts
+++ b/apps/merge/src/lib/fetch-osm-file.ts
@@ -3,7 +3,8 @@ function isSupportedOsmFileName(name: string): boolean {
 	return (
 		lower.endsWith(".pbf") ||
 		lower.endsWith(".geojson") ||
-		lower.endsWith(".json")
+		lower.endsWith(".json") ||
+		lower.endsWith(".zip")
 	)
 }
 
@@ -62,6 +63,8 @@ function extensionFromContentType(contentType: string | null): string | null {
 	if (type === "application/geo+json") return ".geojson"
 	if (type === "application/json") return ".json"
 	if (type === "text/json") return ".json"
+	if (type === "application/zip") return ".zip"
+	if (type === "application/x-zip-compressed") return ".zip"
 	return null
 }
 
@@ -103,7 +106,7 @@ export async function fetchOsmFileFromUrl(
 
 	if (!isSupportedOsmFileName(name)) {
 		throw new Error(
-			`URL must resolve to a .pbf, .geojson, or .json file (got "${name}")`,
+			`URL must resolve to a .pbf, .geojson, .json, or .zip file (got "${name}")`,
 		)
 	}
 


### PR DESCRIPTION
Enable Shapefile (.zip) support for the "Open from URL" flow, as the previous validation rejected `.zip` files despite UI advertisement.

---
<a href="https://cursor.com/background-agent?bcId=bc-9221aafd-e8d3-4a74-8c27-42eea5973c9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9221aafd-e8d3-4a74-8c27-42eea5973c9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

