### PR TITLE
Osc output default restore

### DIFF
--- a/packages/change/README.md
+++ b/packages/change/README.md
@@ -113,15 +113,15 @@ Generates OSC (OSM Change) XML format from a changeset.
 ```ts
 import { generateOscChanges } from "@osmix/change"
 
-// Generate augmented diff OSC (default)
+// Generate standard OSC for API uploads (default)
 const osc = generateOscChanges(changeset)
 
-// Generate standard OSC without augmented data
-const standardOsc = generateOscChanges(changeset, { augmented: false })
+// Generate augmented diff with old/new sections
+const augmentedOsc = generateOscChanges(changeset, { augmented: true })
 ```
 
 Options:
-- `augmented` (boolean, default: `true`): When true, modifications include `<old>` and `<new>` sections, and deletions include `<old>` sections with the full entity data.
+- `augmented` (boolean, default: `false`): When true, modifications include `<old>` and `<new>` sections, and deletions include `<old>` sections with the full entity data.
 
 ## Related Packages
 

--- a/packages/change/src/osc.ts
+++ b/packages/change/src/osc.ts
@@ -54,13 +54,13 @@ export interface OscOptions {
 	 * versions of modified/deleted elements using `<old>` and `<new>` sections.
 	 * See: https://wiki.openstreetmap.org/wiki/Overpass_API/Augmented_Diffs
 	 *
-	 * @default true
+	 * @default false
 	 */
 	augmented: boolean
 }
 
 const DEFAULT_OSC_OPTIONS: OscOptions = {
-	augmented: true,
+	augmented: false,
 }
 
 /**
@@ -69,9 +69,9 @@ const DEFAULT_OSC_OPTIONS: OscOptions = {
  * Produces an `<osmChange>` document with create, modify, and delete sections
  * containing all nodes, ways, and relations from the changeset.
  *
- * When `augmented: true` (default), modifications and deletions include both
- * the old and new versions of elements wrapped in `<old>` and `<new>` elements,
- * following the Overpass API Augmented Diffs format.
+ * By default, generates standard OSC format compatible with OSM API 0.6 uploads.
+ * Set `augmented: true` to include both old and new versions of elements wrapped
+ * in `<old>` and `<new>` elements, following the Overpass API Augmented Diffs format.
  *
  * @param changeset - The changeset to serialize.
  * @param options - Options for OSC generation.
@@ -79,11 +79,11 @@ const DEFAULT_OSC_OPTIONS: OscOptions = {
  *
  * @example
  * ```ts
- * // Generate augmented diff (default)
+ * // Generate standard OSC for API uploads (default)
  * const osc = generateOscChanges(changeset)
  *
- * // Generate standard OSC without augmented data
- * const standardOsc = generateOscChanges(changeset, { augmented: false })
+ * // Generate augmented diff with old/new sections
+ * const augmentedOsc = generateOscChanges(changeset, { augmented: true })
  *
  * await Bun.write('changes.osc', osc)
  * ```

--- a/packages/change/test/augmented-diffs.test.ts
+++ b/packages/change/test/augmented-diffs.test.ts
@@ -89,7 +89,7 @@ describe("augmented diffs", () => {
 	})
 
 	describe("generateOscChanges", () => {
-		it("should generate augmented diffs by default", () => {
+		it("should generate standard OSC format by default", () => {
 			const base = createBaseOsm()
 			const patch = createPatchOsm()
 
@@ -98,12 +98,12 @@ describe("augmented diffs", () => {
 
 			const osc = generateOscChanges(changeset)
 
-			// Check that modify section contains old and new elements
+			// Check that modify section does not contain old/new wrappers
 			expect(osc).toContain("<modify>")
-			expect(osc).toContain("<old>")
-			expect(osc).toContain("<new>")
-			// Old version should have original tags
-			expect(osc).toContain('k="highway"')
+			expect(osc).not.toContain("<old>")
+			expect(osc).not.toContain("<new>")
+			// Should still contain the modified elements directly
+			expect(osc).toContain("<way")
 		})
 
 		it("should generate augmented diffs with old/new for modifications", () => {


### PR DESCRIPTION
Restore standard OSC output as default for `generateOscChanges`.

The previous default (`augmented: true`) caused `generateOscChanges` to produce augmented diffs, which are incompatible with the standard OSM API 0.6 upload schema. This change ensures existing callers relying on the default for uploads will send valid XML.

---
<a href="https://cursor.com/background-agent?bcId=bc-cf189bda-39b7-4f9a-9225-8aebfc52c115"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cf189bda-39b7-4f9a-9225-8aebfc52c115"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

