### PR TITLE
Nav bar github link

### DIFF
--- a/apps/merge/src/components/nav.tsx
+++ b/apps/merge/src/components/nav.tsx
@@ -1,11 +1,5 @@
 import { type PrimitiveAtom, useAtom } from "jotai"
-import {
-	Github,
-	Layers,
-	Navigation,
-	SearchIcon,
-	SidebarClose,
-} from "lucide-react"
+import { Layers, Navigation, SearchIcon, SidebarClose } from "lucide-react"
 import { NavLink } from "react-router"
 import CenterInfo from "../components/center-info"
 import ZoomInfo, { ZoomInButton, ZoomOutButton } from "../components/zoom-info"
@@ -25,15 +19,15 @@ export default function Nav() {
 	return (
 		<div className="shadow z-20 flex flex-row justify-between items-center px-2 lg:px-4 h-10 bg-white">
 			<div className="flex flex-row gap-2 items-center">
-				<div className="font-bold pr-2">OSMIX</div>
 				<a
 					href="https://github.com/conveyal/osmix"
 					target="_blank"
 					rel="noopener noreferrer"
-					className="text-slate-600 hover:text-slate-900"
+					className="hover:opacity-50 size-4"
 				>
-					<Github className="size-5" />
+					<GithubLogo />
 				</a>
+				<div className="font-bold pr-2">OSMIX</div>
 				<NavLink
 					className={({ isActive }) =>
 						cn(
@@ -86,6 +80,7 @@ export default function Nav() {
 					</div>
 					<ZoomInButton />
 				</div>
+				<ButtonGroupSeparator />
 			</ButtonGroup>
 		</div>
 	)
@@ -108,5 +103,14 @@ function ToggleButton({
 		>
 			{children}
 		</Button>
+	)
+}
+
+export function GithubLogo() {
+	return (
+		<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+			<title>GitHub</title>
+			<path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" />
+		</svg>
 	)
 }


### PR DESCRIPTION
Add a GitHub link to the Nav component to point to the OSMIX repository.

---
<a href="https://cursor.com/background-agent?bcId=bc-f6e621ca-433c-4708-b272-9e0db5498699"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f6e621ca-433c-4708-b272-9e0db5498699"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

