### PR TITLE
Benchmarking osmpbf parsing

### DIFF
--- a/apps/bench/package.json
+++ b/apps/bench/package.json
@@ -13,6 +13,7 @@
 	"devDependencies": {
 		"@types/react": "^19.2.0",
 		"@types/react-dom": "^19.2.0",
+		"@types/bun": "catalog:",
 		"@vitejs/plugin-react": "^5.0.4",
 		"@vitest/browser-preview": "^4.0.16",
 		"typescript": "catalog:",

--- a/apps/bench/tsconfig.json
+++ b/apps/bench/tsconfig.json
@@ -2,12 +2,13 @@
 	"$schema": "https://json.schemastore.org/tsconfig",
 	"extends": "@osmix/shared/tsconfig/app.json",
 	"compilerOptions": {
-		"types": ["vite/client"]
+		"types": ["vite/client", "bun"]
 	},
 	"include": [
 		"src",
 		"test/duckdb.test.ts",
 		"test/benchmark.bench.ts",
 		"test/osmpbf-comparison.bench.ts"
-	]
+	],
+	"exclude": ["node_modules", "dist"]
 }

--- a/bun.lock
+++ b/bun.lock
@@ -32,6 +32,7 @@
         "react-map-gl": "^8.0.4",
       },
       "devDependencies": {
+        "@types/bun": "catalog:",
         "@types/react": "^19.2.0",
         "@types/react-dom": "^19.2.0",
         "@vitejs/plugin-react": "^5.0.4",


### PR DESCRIPTION
Add `mitata` and `fast-osmpbf-js` dependencies and implement benchmarks comparing Osmix to `fast-osmpbf-js`.

The benchmark structure accounts for a global state bug in `fast-osmpbf-js`, allowing only single runs for that library, while Osmix is benchmarked with `mitata` for statistical accuracy.

---
<a href="https://cursor.com/background-agent?bcId=bc-34488505-9502-4371-a13e-57a5dd0c769d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-34488505-9502-4371-a13e-57a5dd0c769d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

