### PR TITLE
Add CLAUDE.md referencing AGENTS.md for project instructions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# Claude Code Instructions
+
+See [AGENTS.md](./AGENTS.md) for project guidelines, commands, architecture, and coding standards.


### PR DESCRIPTION
Adds a simple entry point for Claude Code instructions that delegates to the comprehensive AGENTS.md guide.

This provides a consistent place for Claude Code instances to reference project guidelines, commands, architecture, and coding standards.