### PR TITLE
Add filename utility

### DIFF
--- a/apps/merge/src/components/osm-changes-summary.tsx
+++ b/apps/merge/src/components/osm-changes-summary.tsx
@@ -489,7 +489,10 @@ function RefsDiff({
 					<td className="align-top pl-4 text-muted-foreground">removed</td>
 					<td>
 						{deletes.map((op) => (
-							<span key={`del-${op.index}-${op.value}`} className="text-red-600">
+							<span
+								key={`del-${op.index}-${op.value}`}
+								className="text-red-600"
+							>
 								<span className="text-muted-foreground text-xs">
 									[{op.index}]
 								</span>
@@ -505,7 +508,10 @@ function RefsDiff({
 					<td className="align-top pl-4 text-muted-foreground">added</td>
 					<td>
 						{inserts.map((op) => (
-							<span key={`ins-${op.index}-${op.value}`} className="text-green-600">
+							<span
+								key={`ins-${op.index}-${op.value}`}
+								className="text-green-600"
+							>
 								<span className="text-muted-foreground text-xs">
 									[{op.index}]
 								</span>
@@ -656,7 +662,10 @@ function MembersDiff({
 					<td className="align-top pl-4 text-muted-foreground">removed</td>
 					<td>
 						{deletes.map((op) => (
-							<span key={`del-${op.index}-${op.value}`} className="text-red-600">
+							<span
+								key={`del-${op.index}-${op.value}`}
+								className="text-red-600"
+							>
 								<span className="text-muted-foreground text-xs">
 									[{op.index}]
 								</span>
@@ -672,7 +681,10 @@ function MembersDiff({
 					<td className="align-top pl-4 text-muted-foreground">added</td>
 					<td>
 						{inserts.map((op) => (
-							<span key={`ins-${op.index}-${op.value}`} className="text-green-600">
+							<span
+								key={`ins-${op.index}-${op.value}`}
+								className="text-green-600"
+							>
 								<span className="text-muted-foreground text-xs">
 									[{op.index}]
 								</span>

--- a/apps/merge/src/hooks/osm.ts
+++ b/apps/merge/src/hooks/osm.ts
@@ -1,5 +1,6 @@
 import { useAtom, useSetAtom } from "jotai"
 import { showSaveFilePickerWithFallback } from "../lib/save-file-picker"
+import { ensureOsmPbfDownloadName } from "../lib/osm-pbf-download-name"
 import type { OsmFileType, OsmInfo } from "osmix"
 import { useEffectEvent, useRef } from "react"
 import { canStoreFile } from "../lib/storage-utils"
@@ -213,7 +214,8 @@ export function useOsmFile(osmKey: string) {
 		const withPrefix = sourceName.startsWith("osmix-")
 			? sourceName
 			: `osmix-${sourceName}`
-		const suggestedName = name ?? withPrefix
+		const rawSuggestedName = name ?? withPrefix
+		const suggestedName = ensureOsmPbfDownloadName(rawSuggestedName)
 		const fileHandle = await showSaveFilePickerWithFallback(
 			{
 				suggestedName,

--- a/apps/merge/src/lib/osm-pbf-download-name.ts
+++ b/apps/merge/src/lib/osm-pbf-download-name.ts
@@ -1,0 +1,8 @@
+export function ensureOsmPbfDownloadName(filename: string): string {
+	if (filename.toLowerCase().endsWith(".pbf")) return filename
+
+	const lastDot = filename.lastIndexOf(".")
+	if (lastDot <= 0) return `${filename}.pbf`
+
+	return `${filename.slice(0, lastDot)}.pbf`
+}

--- a/apps/merge/tests/osm-pbf-download-name.test.ts
+++ b/apps/merge/tests/osm-pbf-download-name.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "bun:test"
+import { ensureOsmPbfDownloadName } from "../src/lib/osm-pbf-download-name"
+
+describe("ensureOsmPbfDownloadName", () => {
+	it("replaces other extensions with .pbf", () => {
+		expect(ensureOsmPbfDownloadName("foo.geojson")).toBe("foo.pbf")
+		expect(ensureOsmPbfDownloadName("osmix-bar.json")).toBe("osmix-bar.pbf")
+	})
+
+	it("appends .pbf when no extension exists", () => {
+		expect(ensureOsmPbfDownloadName("baz")).toBe("baz.pbf")
+	})
+
+	it("preserves existing .pbf names (case-insensitive)", () => {
+		expect(ensureOsmPbfDownloadName("qux.pbf")).toBe("qux.pbf")
+		expect(ensureOsmPbfDownloadName("QuX.PBF")).toBe("QuX.PBF")
+		expect(ensureOsmPbfDownloadName("already.osm.pbf")).toBe("already.osm.pbf")
+	})
+})


### PR DESCRIPTION
- Introduced a new utility function `ensureOsmPbfDownloadName` to ensure filenames have a `.pbf` extension.
- Added tests for the new filename utility to validate its functionality.

Fixes #170 