### PR TITLE
Use published kdbush package for pnpm compatibility

### DIFF
--- a/.changeset/hot-pandas-draw.md
+++ b/.changeset/hot-pandas-draw.md
@@ -1,0 +1,5 @@
+---
+"@osmix/core": patch
+---
+
+Use published kdbush package for pnpm compatibility

--- a/bun.lock
+++ b/bun.lock
@@ -163,7 +163,7 @@
         "flatbush": "^4.5.1",
         "geoflatbush": "^2.1.0",
         "geokdbush": "^2.1.0",
-        "kdbush": "mourner/kdbush#16416cd",
+        "kdbush": "^4.0.2",
       },
       "devDependencies": {
         "@osmix/pbf": "workspace:*",
@@ -1192,7 +1192,7 @@
 
     "jsonfile": ["jsonfile@4.0.0", "", { "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg=="],
 
-    "kdbush": ["kdbush@github:mourner/kdbush#16416cd", {}, "mourner-kdbush-16416cd"],
+    "kdbush": ["kdbush@4.0.2", "", {}, "sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA=="],
 
     "lightningcss": ["lightningcss@1.30.2", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.30.2", "lightningcss-darwin-arm64": "1.30.2", "lightningcss-darwin-x64": "1.30.2", "lightningcss-freebsd-x64": "1.30.2", "lightningcss-linux-arm-gnueabihf": "1.30.2", "lightningcss-linux-arm64-gnu": "1.30.2", "lightningcss-linux-arm64-musl": "1.30.2", "lightningcss-linux-x64-gnu": "1.30.2", "lightningcss-linux-x64-musl": "1.30.2", "lightningcss-win32-arm64-msvc": "1.30.2", "lightningcss-win32-x64-msvc": "1.30.2" } }, "sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ=="],
 
@@ -1757,8 +1757,6 @@
     "string-width-cjs/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "string-width-cjs/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
-
-    "supercluster/kdbush": ["kdbush@4.0.2", "", {}, "sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA=="],
 
     "supertap/js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,6 +26,6 @@
 		"flatbush": "^4.5.1",
 		"geoflatbush": "^2.1.0",
 		"geokdbush": "^2.1.0",
-		"kdbush": "mourner/kdbush#16416cd"
+		"kdbush": "^4.0.2"
 	}
 }


### PR DESCRIPTION
Replace the GitHub commit pin with kdbush@^4.0.2 so @osmix/core installs under pnpm, which cannot resolve arbitrary short commit SHAs.

Fixes #189