### PR TITLE
Add shared worker runtime and feature indexing

### DIFF
--- a/.changeset/bright-workers-share.md
+++ b/.changeset/bright-workers-share.md
@@ -1,0 +1,10 @@
+---
+"@osmix/shared": minor
+"@osmix/shortbread": minor
+"@osmix/core": patch
+"osmix": minor
+---
+
+Add a cross-runtime managed worker pool with browser, Bun, Deno, and Node worker support,
+cooperative cancellation utilities, a transferable Shortbread feature index, and worker-backed
+consumer integrations.

--- a/.changeset/calm-rasters-draw.md
+++ b/.changeset/calm-rasters-draw.md
@@ -1,0 +1,5 @@
+---
+"@osmix/raster": minor
+---
+
+Add configurable point radii and variable-width raster line drawing with round caps and joins.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [24, 26]
+        node: [20, 22, 24]
 
     steps:
       - name: Checkout repository
@@ -44,7 +44,9 @@ jobs:
       - name: Setup Node.js for package preparation
         uses: actions/setup-node@v6
         with:
-          node-version: ${{ matrix.node }}
+          # pnpm 11 uses node:sqlite and therefore needs a newer preparation
+          # runtime than the oldest Node version supported by the packed API.
+          node-version: 24
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ apps/**/dist/
 
 # Dependencies
 node_modules/
+.pnpm-store/
 packages/**/node_modules/
 apps/**/node_modules/
 

--- a/apps/merge/README.md
+++ b/apps/merge/README.md
@@ -11,7 +11,7 @@ Osmix Merge is a Vite + React app for comparing and reconciling OpenStreetMap PB
 
 ## Prerequisites
 
-- Bun `1.3.x`
+- Node.js 20+ and pnpm
 - Modern Chromium-based browser (Chrome/Edge ≥ 119 recommended). Safari/Firefox lack the `showSaveFilePicker` API and stable OffscreenCanvas transfer support.
 - Running over `https://` or `http://localhost` so COOP/COEP headers can enable `crossOriginIsolated` mode for the worker raster pipeline.
 
@@ -72,8 +72,10 @@ The stepper resets selection state between actions, and you can jump backward or
 
 ## Worker architecture
 
-- All heavy operations (PBF ingest, change generation, raster rendering) happen inside `src/workers/osm.worker.ts`, keeping the main thread responsive.
-- The worker caches `Osmix` instances keyed by dataset id, exposes change pagination, and returns transferable typed arrays whenever possible.
+- All heavy operations (PBF ingest, change generation, routing, and tile rendering) run in a managed worker pool, keeping the main thread responsive. Cross-origin-isolated browsers reserve one logical core for the UI and use up to four workers.
+- Stateful loading, IndexedDB writes, and changesets stay on the control worker. Read-only tiles and queries use available compute workers, with queued MapLibre tile requests cancelled when the map no longer needs them.
+- Workers cache `Osmix` instances keyed by dataset id, share their backing buffers, expose change pagination, and return transferable typed arrays whenever possible.
+- If a single non-shared worker restarts, datasets previously loaded from IndexedDB are reconstructed with a read-only replay before the slot accepts more work. One-shot mutations and IndexedDB writes are never retried.
 - Logs from the worker are proxied back through `Log.addMessage` so long-running operations surface status updates.
 
 ## Data loading tips

--- a/apps/merge/e2e/worker-harness.html
+++ b/apps/merge/e2e/worker-harness.html
@@ -130,7 +130,10 @@
 
       async function runDispose() {
         const remote = await createRemote({ workerCount: 1 });
-        const worker = remote.getWorker();
+        let worker;
+        await remote.runWithWorker((candidate) => {
+          worker = candidate;
+        });
         remote.terminate();
         remote[Symbol.dispose]();
 
@@ -155,12 +158,149 @@
         };
       }
 
+      async function runManagedScheduling() {
+        const remote = await createRemote({ workerCount: 2 });
+        try {
+          const dataset = await loadMonaco(remote, "managed-scheduling-monaco");
+          const completionOrder = [];
+          const slow = remote.runWithWorker(
+            async (worker, index) => {
+              await new Promise((resolve) => setTimeout(resolve, 80));
+              completionOrder.push("slow");
+              return { index, nodes: await worker.nodesSize(dataset.id) };
+            },
+            { lane: "compute" },
+          );
+
+          await new Promise((resolve) => setTimeout(resolve, 10));
+          const abortController = new AbortController();
+          let abortedTaskRan = false;
+          const aborted = remote
+            .runWithWorker(
+              () => {
+                abortedTaskRan = true;
+              },
+              { lane: "compute", signal: abortController.signal },
+            )
+            .then(
+              () => false,
+              () => true,
+            );
+          const low = remote.runWithWorker(() => completionOrder.push("low"), {
+            lane: "compute",
+            priority: 0,
+          });
+          const high = remote.runWithWorker(() => completionOrder.push("high"), {
+            lane: "compute",
+            priority: 10,
+          });
+          abortController.abort();
+
+          const [slowResult, wasAborted] = await Promise.all([slow, aborted, low, high]);
+          const controlIndex = await remote.runWithWorker((_worker, index) => index, {
+            lane: "control",
+          });
+          const computeIndex = await remote.runWithWorker((_worker, index) => index, {
+            lane: "compute",
+          });
+
+          return {
+            abortedTaskRan,
+            completionOrder,
+            computeIndex,
+            controlIndex,
+            slowResult,
+            wasAborted,
+          };
+        } finally {
+          remote[Symbol.dispose]();
+        }
+      }
+
+      function inspectBuffers(value) {
+        const buffers = new Set();
+        const visited = new WeakSet();
+        const visit = (candidate) => {
+          if (
+            candidate instanceof ArrayBuffer ||
+            (typeof SharedArrayBuffer !== "undefined" && candidate instanceof SharedArrayBuffer)
+          ) {
+            buffers.add(candidate);
+            return;
+          }
+          if (ArrayBuffer.isView(candidate)) {
+            buffers.add(candidate.buffer);
+            return;
+          }
+          if (!candidate || (typeof candidate !== "object" && typeof candidate !== "function")) {
+            return;
+          }
+          if (visited.has(candidate)) return;
+          visited.add(candidate);
+          for (const child of Object.values(candidate)) visit(child);
+        };
+        visit(value);
+        const sharedBufferCount = [...buffers].filter(
+          (buffer) => buffer instanceof SharedArrayBuffer,
+        ).length;
+        return {
+          allShared: buffers.size > 0 && sharedBufferCount === buffers.size,
+          bufferCount: buffers.size,
+          sharedBufferCount,
+        };
+      }
+
+      async function runTimeoutRecoveryAndSharing() {
+        const remote = await createRemote({ workerCount: 2 });
+        try {
+          const dataset = await loadMonaco(remote, "recovery-sharing-monaco");
+          let attempts = 0;
+          const recovered = await remote.runWithWorker(
+            async (worker, index) => {
+              attempts++;
+              if (attempts === 1) return new Promise(() => {});
+              return { index, nodes: await worker.nodesSize(dataset.id) };
+            },
+            { lane: "compute", retry: "once", timeoutMs: 250 },
+          );
+
+          const inspectWorker = async (worker, index) => {
+            const [hasDataset, nodes, transferables] = await Promise.all([
+              worker.has(dataset.id),
+              worker.nodesSize(dataset.id),
+              worker.getOsmBuffers(dataset.id),
+            ]);
+            return {
+              ...inspectBuffers(transferables),
+              contentHash: transferables.contentHash,
+              hasDataset,
+              index,
+              nodes,
+            };
+          };
+          const control = await remote.runWithWorker(inspectWorker, { lane: "control" });
+          const compute = await remote.runWithWorker(inspectWorker, { lane: "compute" });
+
+          return {
+            attempts,
+            compute,
+            control,
+            matchingContentHashes: control.contentHash === compute.contentHash,
+            recovered,
+          };
+        } finally {
+          remote[Symbol.dispose]();
+        }
+      }
+
       window.workerHarness = {
         runDispose,
+        runManagedScheduling,
         runMultiWorker,
         runReservedIds,
         runSingleWorker,
         runSingleWorkerTransfer,
+        runTimeoutRecoveryAndSharing,
       };
     </script>
   </body>

--- a/apps/merge/e2e/worker-runtime.spec.ts
+++ b/apps/merge/e2e/worker-runtime.spec.ts
@@ -46,14 +46,43 @@ interface ReservedIdsResult {
   survivorNodeCounts: number[];
 }
 
+interface ManagedSchedulingResult {
+  abortedTaskRan: boolean;
+  completionOrder: string[];
+  computeIndex: number;
+  controlIndex: number;
+  slowResult: { index: number; nodes: number };
+  wasAborted: boolean;
+}
+
+interface WorkerDatasetInspection {
+  allShared: boolean;
+  bufferCount: number;
+  contentHash: string;
+  hasDataset: boolean;
+  index: number;
+  nodes: number;
+  sharedBufferCount: number;
+}
+
+interface TimeoutRecoveryAndSharingResult {
+  attempts: number;
+  compute: WorkerDatasetInspection;
+  control: WorkerDatasetInspection;
+  matchingContentHashes: boolean;
+  recovered: { index: number; nodes: number };
+}
+
 declare global {
   interface Window {
     workerHarness: {
       runDispose: () => Promise<DisposeResult>;
+      runManagedScheduling: () => Promise<ManagedSchedulingResult>;
       runSingleWorker: () => Promise<SingleWorkerResult>;
       runSingleWorkerTransfer: () => Promise<SingleWorkerTransferResult>;
       runMultiWorker: () => Promise<MultiWorkerResult>;
       runReservedIds: (workerCount: number) => Promise<ReservedIdsResult>;
+      runTimeoutRecoveryAndSharing: () => Promise<TimeoutRecoveryAndSharingResult>;
     };
   }
 }
@@ -84,6 +113,41 @@ test("multi-worker replicates Monaco in a cross-origin isolated page", async ({ 
   expect(result.relationCounts).toEqual([46, 46]);
   expect(result.vectorByteLengths).toHaveLength(2);
   expect(result.vectorByteLengths.every((length) => length > 0)).toBe(true);
+});
+
+test("managed scheduling prioritizes and cancels queued compute work", async ({ page }) => {
+  const result = await page.evaluate(() => window.workerHarness.runManagedScheduling());
+
+  expect(result.controlIndex).toBe(0);
+  expect(result.computeIndex).toBe(1);
+  expect(result.slowResult).toEqual({ index: 1, nodes: 14_286 });
+  expect(result.completionOrder).toEqual(["slow", "high", "low"]);
+  expect(result.wasAborted).toBe(true);
+  expect(result.abortedTaskRan).toBe(false);
+});
+
+test("timed-out compute workers restart with one shared Monaco dataset", async ({ page }) => {
+  const result = await page.evaluate(() => window.workerHarness.runTimeoutRecoveryAndSharing());
+
+  expect(result.attempts).toBe(2);
+  expect(result.recovered).toEqual({ index: 1, nodes: 14_286 });
+  expect(result.matchingContentHashes).toBe(true);
+  expect(result.control).toMatchObject({
+    allShared: true,
+    hasDataset: true,
+    index: 0,
+    nodes: 14_286,
+  });
+  expect(result.compute).toMatchObject({
+    allShared: true,
+    hasDataset: true,
+    index: 1,
+    nodes: 14_286,
+  });
+  expect(result.control.bufferCount).toBeGreaterThan(0);
+  expect(result.control.sharedBufferCount).toBe(result.control.bufferCount);
+  expect(result.compute.bufferCount).toBeGreaterThan(0);
+  expect(result.compute.sharedBufferCount).toBe(result.compute.bufferCount);
 });
 
 test("single worker transfers sorted Monaco IDs without cloning errors", async ({ page }) => {

--- a/apps/merge/src/hooks/osm.ts
+++ b/apps/merge/src/hooks/osm.ts
@@ -59,7 +59,7 @@ export function useOsmFile(osmKey: string) {
         // Check after file read
         if (signal?.aborted) throw new LoadCancelledError();
 
-        const fileHash = await osmWorker.hashBuffer(buffer);
+        const fileHash = await osmWorker.hashBuffer(buffer, signal);
 
         // Check after hashing
         if (signal?.aborted) throw new LoadCancelledError();
@@ -72,14 +72,14 @@ export function useOsmFile(osmKey: string) {
         setFileInfo(storedFileInfo);
 
         // Check if we already have this file stored (in worker)
-        const existing = await osmWorker.findByHash(fileHash);
+        const existing = await osmWorker.findByHash(fileHash, signal);
 
         // Check after cache lookup
         if (signal?.aborted) throw new LoadCancelledError();
 
         if (existing) {
           taskLog.update("Found cached version, loading from storage...");
-          const stored = await osmWorker.loadFromStorage(existing.fileHash);
+          const stored = await osmWorker.loadFromStorage(existing.fileHash, signal);
 
           // Check after loading from storage
           if (signal?.aborted) throw new LoadCancelledError();
@@ -120,7 +120,7 @@ export function useOsmFile(osmKey: string) {
         taskLog.end(`${file.name} loaded.`);
         return osmInfo;
       } catch (e) {
-        if (e instanceof LoadCancelledError) {
+        if (signal?.aborted || e instanceof LoadCancelledError) {
           // Only reset state if this is still the current load
           // (prevents stale cancellations from clearing newer load state)
           if (loadId === currentLoadIdRef.current) {
@@ -164,7 +164,7 @@ export function useOsmFile(osmKey: string) {
         const buffer = await file.arrayBuffer();
         if (signal?.aborted) throw new LoadCancelledError();
 
-        const fileHash = await osmWorker.hashBuffer(buffer);
+        const fileHash = await osmWorker.hashBuffer(buffer, signal);
         if (signal?.aborted) throw new LoadCancelledError();
 
         const storedFileInfo: StoredFileInfo = {
@@ -199,7 +199,7 @@ export function useOsmFile(osmKey: string) {
         taskLog.end(`${file.name} extracted.`);
         return osmInfo;
       } catch (e) {
-        if (e instanceof LoadCancelledError) {
+        if (signal?.aborted || e instanceof LoadCancelledError) {
           if (loadId === currentLoadIdRef.current) {
             setFile(null);
             setFileInfo(null);
@@ -225,7 +225,7 @@ export function useOsmFile(osmKey: string) {
       if (signal?.aborted) throw new LoadCancelledError();
 
       // Load from IndexedDB in the worker
-      const stored = await osmWorker.loadFromStorage(storageId);
+      const stored = await osmWorker.loadFromStorage(storageId, signal);
 
       // Check after loading from storage
       if (signal?.aborted) throw new LoadCancelledError();
@@ -258,7 +258,7 @@ export function useOsmFile(osmKey: string) {
       taskLog.end(`${stored.entry.fileName} loaded from storage.`);
       return osmInfo;
     } catch (e) {
-      if (e instanceof LoadCancelledError) {
+      if (signal?.aborted || e instanceof LoadCancelledError) {
         // Only reset state if this is still the current load
         // (prevents stale cancellations from clearing newer load state)
         if (loadId === currentLoadIdRef.current) {

--- a/apps/merge/src/lib/merge-remote.ts
+++ b/apps/merge/src/lib/merge-remote.ts
@@ -5,8 +5,15 @@
  * methods, following the same pattern as the base OsmixRemote class.
  */
 
+import type { Remote } from "comlink";
 import type { Progress } from "osmix";
-import { type OsmId, type OsmInfo, OsmixRemote } from "osmix";
+import {
+  getOsmixCapabilities,
+  type OsmId,
+  type OsmInfo,
+  OsmixRemote,
+  selectWorkerCount,
+} from "osmix";
 
 import type { MergeWorker, StoredFileInfo, StoredOsmEntry } from "../workers/osm.worker";
 // oxlint-disable-next-line import/default -- Vite ?worker&url resolves to a string URL
@@ -28,8 +35,12 @@ export interface MergeRemoteOptions {
  */
 export async function createMergeRemote(options: MergeRemoteOptions = {}): Promise<MergeRemote> {
   const remote = new MergeRemote();
+  const hardwareConcurrency = typeof navigator === "undefined" ? 1 : navigator.hardwareConcurrency;
+  const defaultWorkerCount = getOsmixCapabilities().canShareArrayBuffers
+    ? selectWorkerCount({ hardwareConcurrency, reserveCores: 1, maxWorkers: 4 })
+    : 1;
   await remote.initializeWorkerPool(
-    options.workerCount ?? 1,
+    options.workerCount ?? defaultWorkerCount,
     new URL(OsmWorkerUrl, import.meta.url),
     options.onProgress,
   );
@@ -44,28 +55,44 @@ export async function createMergeRemote(options: MergeRemoteOptions = {}): Promi
  * are delegated to workers to keep the main thread responsive.
  */
 export class MergeRemote extends OsmixRemote<MergeWorker> {
+  private readonly storageRecoveryIds = new Map<string, string>();
+
   /**
    * Compute SHA-256 hash of an ArrayBuffer in a worker.
    * Returns the hash as a hex string.
    */
-  hashBuffer(data: ArrayBuffer): Promise<string> {
-    return this.getWorker().hashBuffer(data);
+  hashBuffer(data: ArrayBuffer, signal?: AbortSignal): Promise<string> {
+    return this.runWithWorker((worker) => worker.hashBuffer(data), {
+      lane: "compute",
+      retry: "once",
+      signal,
+    });
   }
 
   /**
    * Find a stored entry by file hash.
    * Returns the stored entry metadata if found, null otherwise.
    */
-  findByHash(hash: string): Promise<StoredOsmEntry | null> {
-    return this.getWorker().findByHash(hash);
+  findByHash(hash: string, signal?: AbortSignal): Promise<StoredOsmEntry | null> {
+    return this.runWithWorker((worker) => worker.findByHash(hash), {
+      lane: "control",
+      retry: "once",
+      signal,
+    });
   }
 
   /**
    * Store the currently-loaded Osm instance to IndexedDB.
    * The Osm must already be loaded in the worker (via fromPbf, etc.).
    */
-  storeCurrentOsm(osmId: OsmId, fileInfo: StoredFileInfo): Promise<void> {
-    return this.getWorker().storeCurrentOsm(this.getId(osmId), fileInfo);
+  async storeCurrentOsm(osmId: OsmId, fileInfo: StoredFileInfo): Promise<void> {
+    const id = this.getId(osmId);
+    await this.runWithWorker((worker) => worker.storeCurrentOsm(id, fileInfo), {
+      lane: "control",
+      retry: "never",
+    });
+    this.storageRecoveryIds.set(id, fileInfo.fileHash);
+    this.registerDatasetForRecovery(id);
   }
 
   /**
@@ -73,43 +100,95 @@ export class MergeRemote extends OsmixRemote<MergeWorker> {
    * Builds spatial indexes automatically after loading.
    * Returns the entry and info if found, null otherwise.
    */
-  async loadFromStorage(osmId: OsmId): Promise<{
+  async loadFromStorage(
+    osmId: OsmId,
+    signal?: AbortSignal,
+  ): Promise<{
     entry: StoredOsmEntry;
     info: OsmInfo;
   } | null> {
-    const worker = this.getWorker();
-    const osmEntry = await worker.loadFromStorage(this.getId(osmId));
-    if (!osmEntry) return null;
-    await this.populateOtherWorkers(worker, osmId);
-    return osmEntry;
+    const storageId = this.getId(osmId);
+    const result = await this.runWithWorker(
+      async (worker) => {
+        const osmEntry = await worker.loadFromStorage(storageId);
+        if (!osmEntry) return null;
+        await this.populateOtherWorkers(worker, osmEntry.entry.fileHash);
+        return osmEntry;
+      },
+      { lane: "control", retry: "never", signal },
+    );
+    if (result) {
+      this.storageRecoveryIds.set(result.entry.fileHash, storageId);
+      this.registerDatasetForRecovery(result.entry.fileHash);
+    }
+    return result;
+  }
+
+  override async delete(osmId: OsmId): Promise<void> {
+    this.storageRecoveryIds.delete(this.getId(osmId));
+    await super.delete(osmId);
+  }
+
+  override async rename(fromId: OsmId, toId: string): Promise<void> {
+    const from = this.getId(fromId);
+    const storageId = this.storageRecoveryIds.get(from);
+    this.storageRecoveryIds.delete(from);
+    if (storageId) this.storageRecoveryIds.set(toId, storageId);
+    await super.rename(from, toId);
+  }
+
+  protected override async recoverDataset(
+    worker: Remote<MergeWorker>,
+    datasetId: string,
+  ): Promise<boolean> {
+    const storageId = this.storageRecoveryIds.get(datasetId);
+    if (!storageId) return false;
+    // Recovery is a read-only IndexedDB replay. It must not update access metadata.
+    await worker.loadFromStorage(storageId, false, datasetId);
+    return worker.has(datasetId);
   }
 
   /**
    * Get all stored Osm entries (metadata only).
    */
   listStoredOsm(): Promise<StoredOsmEntry[]> {
-    return this.getWorker().listStoredOsm();
+    return this.runWithWorker((worker) => worker.listStoredOsm(), {
+      lane: "control",
+      retry: "once",
+    });
   }
 
   /**
    * Delete a stored Osm entry from IndexedDB.
    */
   deleteStoredOsm(id: string): Promise<void> {
-    return this.getWorker().deleteStoredOsm(id);
+    return this.runWithWorker((worker) => worker.deleteStoredOsm(id), {
+      lane: "control",
+      retry: "never",
+    }).then(async () => {
+      this.storageRecoveryIds.delete(id);
+      await super.delete(id);
+    });
   }
 
   /**
    * Rename a stored Osm entry in IndexedDB.
    */
   renameStoredOsm(id: string, newFileName: string): Promise<void> {
-    return this.getWorker().renameStoredOsm(id, newFileName);
+    return this.runWithWorker((worker) => worker.renameStoredOsm(id, newFileName), {
+      lane: "control",
+      retry: "never",
+    });
   }
 
   /**
    * Get storage statistics.
    */
   getStorageStats(): Promise<{ count: number; estimatedBytes: number }> {
-    return this.getWorker().getStorageStats();
+    return this.runWithWorker((worker) => worker.getStorageStats(), {
+      lane: "control",
+      retry: "once",
+    });
   }
 
   /**
@@ -117,6 +196,9 @@ export class MergeRemote extends OsmixRemote<MergeWorker> {
    * Returns null if no entries exist.
    */
   getMostRecentlyUsed(): Promise<StoredOsmEntry | null> {
-    return this.getWorker().getMostRecentlyUsed();
+    return this.runWithWorker((worker) => worker.getMostRecentlyUsed(), {
+      lane: "control",
+      retry: "once",
+    });
   }
 }

--- a/apps/merge/src/lib/osmix-raster-protocol.ts
+++ b/apps/merge/src/lib/osmix-raster-protocol.ts
@@ -16,7 +16,7 @@ export function osmixIdToTileUrl(osmId: string, tileSize: number) {
 export function addOsmixRasterProtocol() {
   maplibre.addProtocol(
     RASTER_PROTOCOL_NAME,
-    async (req): Promise<maplibregl.GetResourceResponse<ArrayBuffer>> => {
+    async (req, abortController): Promise<maplibregl.GetResourceResponse<ArrayBuffer>> => {
       // @osmix/raster://<osmId>/<tileSize>/<z>/<x>/<y>.png
       const m = /^@osmix\/raster:\/\/([^/]+)\/(\d+)\/(\d+)\/(\d+)\/(\d+)\.png$/.exec(req.url);
       if (!m) throw new Error(`Bad ${RASTER_PROTOCOL_NAME} URL: ${req.url}`);
@@ -24,9 +24,15 @@ export function addOsmixRasterProtocol() {
 
       const tileSize = +sizeStr;
       const tileIndex: Tile = [+xStr, +yStr, +zStr];
-      const rasterTile = await osmWorker.getRasterTile(decodeURIComponent(osmId), tileIndex, {
-        tileSize,
-      });
+      const id = decodeURIComponent(osmId);
+      const rasterTile = await osmWorker.runWithWorker(
+        (worker) => worker.getRasterTile(id, tileIndex, { tileSize }),
+        {
+          lane: "compute",
+          retry: "once",
+          signal: abortController.signal,
+        },
+      );
       const data = await rasterTileToImageBuffer(rasterTile, tileSize);
       return {
         data,

--- a/apps/merge/src/lib/osmix-vector-protocol.ts
+++ b/apps/merge/src/lib/osmix-vector-protocol.ts
@@ -21,7 +21,12 @@ export function addOsmixVectorProtocol() {
       if (!match) throw new Error(`Bad @osmix/vector URL: ${req.url}`);
       const [, osmId, zStr, xStr, yStr] = match;
       const tileIndex: Tile = [+xStr, +yStr, +zStr];
-      const data = await osmWorker.getVectorTile(decodeURIComponent(osmId), tileIndex);
+      const id = decodeURIComponent(osmId);
+      const data = await osmWorker.runWithWorker((worker) => worker.getVectorTile(id, tileIndex), {
+        lane: "compute",
+        retry: "once",
+        signal: abortController.signal,
+      });
 
       return {
         data: abortController.signal.aborted ? null : data,

--- a/apps/merge/src/workers/osm.worker.ts
+++ b/apps/merge/src/workers/osm.worker.ts
@@ -143,7 +143,11 @@ export class MergeWorker extends OsmixWorker {
    * Updates the lastAccessedAt timestamp.
    * Returns the OsmInfo if found, null otherwise.
    */
-  async loadFromStorage(storageId: string): Promise<{
+  async loadFromStorage(
+    storageId: string,
+    updateLastAccessed = true,
+    targetId?: string,
+  ): Promise<{
     entry: StoredOsmEntry;
     info: OsmInfo;
   } | null> {
@@ -151,19 +155,20 @@ export class MergeWorker extends OsmixWorker {
     const stored = await db.get(OSM_STORE, storageId);
     if (!stored) return null;
 
-    // Update lastAccessedAt timestamp
-    const now = Date.now();
-    stored.lastAccessedAt = now;
-    await db.put(OSM_STORE, stored);
-    this.notifyStorageChange();
+    const now = updateLastAccessed ? Date.now() : (stored.lastAccessedAt ?? stored.storedAt);
+    if (updateLastAccessed) {
+      stored.lastAccessedAt = now;
+      await db.put(OSM_STORE, stored);
+      this.notifyStorageChange();
+    }
 
     // Convert from storage format and reconstruct Osm
     const transferables = fromStorableTransferables(stored);
-    const osm = new Osm(transferables);
+    const osm = new Osm({ ...transferables, id: targetId ?? stored.fileHash });
     osm.buildSpatialIndexes();
 
     // Register in worker (this also creates VT encoder and rebuilds routing graph if exists)
-    this.set(stored.fileHash, osm);
+    this.set(osm.id, osm);
 
     return {
       entry: {

--- a/apps/shortbread/app.ts
+++ b/apps/shortbread/app.ts
@@ -10,9 +10,12 @@ import type { ShortbreadWorker } from "./shortbread.worker.ts";
 
 export type ShortbreadServerDataset = Pick<
   OsmRemoteDataset<ShortbreadWorker>,
-  "id" | "isReady" | "get" | "delete"
+  "id" | "bbox" | "header" | "stats" | "isReady" | "delete"
 >;
-export type ShortbreadServerRemote = Pick<OsmixRemote<ShortbreadWorker>, "fromPbf" | "getWorker">;
+export type ShortbreadServerRemote = Pick<
+  OsmixRemote<ShortbreadWorker>,
+  "fromPbf" | "runWithWorker"
+>;
 
 export interface ShortbreadServerState {
   dataset: ShortbreadServerDataset;
@@ -62,18 +65,17 @@ export function createShortbreadServerApp({
   });
 
   app.get("/meta.json", async (c) => {
-    const osm = await state.dataset.get();
-    const bbox = osm.bbox();
+    const { bbox, header, stats } = state.dataset;
     const center = [(bbox[0] + bbox[2]) / 2, (bbox[1] + bbox[3]) / 2];
     return c.json({
       filename: state.filename,
       bbox,
       center,
-      header: osm.header,
+      header,
       layerNames: ShortbreadVtEncoder.layerNames,
-      nodes: osm.nodes.size,
-      ways: osm.ways.size,
-      relations: osm.relations.size,
+      nodes: stats.nodes,
+      ways: stats.ways,
+      relations: stats.relations,
     });
   });
 
@@ -127,9 +129,14 @@ export function createShortbreadServerApp({
     console.time(url);
     try {
       const { x, y, z } = c.req.param();
-      const tile = await remote
-        .getWorker()
-        .getShortbreadTile(state.dataset.id, [+x, +y, +z] as Tile);
+      const tile = await remote.runWithWorker(
+        (worker) => worker.getShortbreadTile(state.dataset.id, [+x, +y, +z] as Tile),
+        {
+          lane: "compute",
+          retry: "once",
+          signal: c.req.raw.signal,
+        },
+      );
       return c.body(tile, 200, {
         "content-type": "application/vnd.mapbox-vector-tile",
         "access-control-allow-origin": "*",

--- a/apps/shortbread/package.json
+++ b/apps/shortbread/package.json
@@ -4,14 +4,16 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "node --watch server.ts",
-    "start": "node server.ts",
-    "test": "node --experimental-strip-types test/server.test.ts",
+    "dev": "node --import tsx --watch server.ts",
+    "start": "node --import tsx server.ts",
+    "stress:regional": "node --import tsx test/regional-stress.ts",
+    "test": "node --import tsx test/server.test.ts",
     "typecheck": "tsc --build --noEmit"
   },
   "dependencies": {
     "@hono/node-server": "^2.0.8",
     "@osmix/core": "workspace:*",
+    "@osmix/shared": "workspace:*",
     "@osmix/shortbread": "workspace:*",
     "@osmix/types": "workspace:*",
     "@versatiles/style": "^5.13.0",
@@ -22,7 +24,7 @@
   },
   "devDependencies": {
     "@osmix/pbf": "workspace:*",
-    "@osmix/shared": "workspace:*",
+    "tsx": "^4.23.0",
     "typescript": "catalog:"
   }
 }

--- a/apps/shortbread/remote.ts
+++ b/apps/shortbread/remote.ts
@@ -1,0 +1,91 @@
+import { inspectBackingBuffers } from "@osmix/shared/backing-buffers";
+import type { ShortbreadFeatureIndexTransferables } from "@osmix/shortbread";
+import type { Remote } from "comlink";
+import type { Progress } from "osmix";
+import { canShareArrayBuffers, type OsmId, OsmixRemote } from "osmix";
+
+import type { ShortbreadWorker } from "./shortbread.worker.ts";
+
+export interface CreateShortbreadRemoteOptions {
+  onProgress?: (progress: Progress) => void;
+  workerCount: number;
+  workerUrl: URL;
+}
+
+/** Create a Shortbread remote whose feature indexes are shared and recoverable. */
+export async function createShortbreadRemote({
+  onProgress,
+  workerCount,
+  workerUrl,
+}: CreateShortbreadRemoteOptions): Promise<ShortbreadRemote> {
+  const remote = new ShortbreadRemote();
+  await remote.initializeWorkerPool(workerCount, workerUrl, onProgress);
+  return remote;
+}
+
+/** Osmix remote that prepares one shared Shortbread index for each dataset. */
+export class ShortbreadRemote extends OsmixRemote<ShortbreadWorker> {
+  private readonly featureIndexes = new Map<string, ShortbreadFeatureIndexTransferables>();
+  private readonly featureIndexIds = new Set<string>();
+
+  override async fromPbf(...args: Parameters<OsmixRemote<ShortbreadWorker>["fromPbf"]>) {
+    const dataset = await super.fromPbf(...args);
+    await this.prepareFeatureIndex(dataset.id);
+    return dataset;
+  }
+
+  override async delete(osmId: OsmId): Promise<void> {
+    const id = this.getId(osmId);
+    this.featureIndexes.delete(id);
+    this.featureIndexIds.delete(id);
+    await super.delete(osmId);
+  }
+
+  /** Inspect each worker's shared feature-index installation for stress diagnostics. */
+  getFeatureIndexDiagnostics(osmId: OsmId) {
+    const id = this.getId(osmId);
+    return this.broadcastToWorkers((worker) => worker.getShortbreadFeatureIndexInfo(id), {
+      retry: "once",
+    });
+  }
+
+  protected override async rehydrateWorker(worker: Remote<ShortbreadWorker>): Promise<void> {
+    for (const id of this.featureIndexIds) {
+      const transferables = this.featureIndexes.get(id);
+      if (transferables) {
+        await worker.setShortbreadFeatureIndex(id, transferables);
+      } else {
+        // A non-shared index is intentionally not retained on the main thread.
+        await worker.buildShortbreadFeatureIndexInPlace(id);
+      }
+    }
+  }
+
+  private async prepareFeatureIndex(id: string): Promise<void> {
+    this.featureIndexIds.add(id);
+    if (!canShareArrayBuffers()) {
+      await this.runWithWorker((worker) => worker.buildShortbreadFeatureIndexInPlace(id), {
+        lane: "control",
+        retry: "once",
+      });
+      this.featureIndexes.delete(id);
+      return;
+    }
+    const transferables = await this.runWithWorker(
+      (worker) => worker.buildShortbreadFeatureIndex(id),
+      { lane: "control", retry: "once" },
+    );
+    const buffers = inspectBackingBuffers(transferables);
+    if (buffers.unique > 0 && buffers.shared === buffers.unique) {
+      this.featureIndexes.set(id, transferables);
+    } else {
+      this.featureIndexes.delete(id);
+      // The control worker already owns this non-shared index. Sending it back
+      // through Comlink would create a transient full clone for no benefit.
+      return;
+    }
+    await this.broadcastToWorkers((worker) => worker.setShortbreadFeatureIndex(id, transferables), {
+      retry: "once",
+    });
+  }
+}

--- a/apps/shortbread/server.ts
+++ b/apps/shortbread/server.ts
@@ -1,14 +1,14 @@
 import { createReadStream, readFileSync } from "node:fs";
-import os from "node:os";
+import { availableParallelism } from "node:os";
 import { Readable } from "node:stream";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 import { serve } from "@hono/node-server";
 import type { Progress } from "@osmix/shared/progress";
-import { createRemote } from "osmix";
+import { selectWorkerCount } from "osmix";
 
 import { createShortbreadServerApp } from "./app.ts";
-import type { ShortbreadWorker } from "./shortbread.worker.ts";
+import { createShortbreadRemote } from "./remote.ts";
 
 export async function startShortbreadServer() {
   const filename = "monaco.pbf";
@@ -16,8 +16,12 @@ export async function startShortbreadServer() {
   const pbfPath = fileURLToPath(new URL(`../../fixtures/${filename}`, import.meta.url));
   const indexHtml = readFileSync(fileURLToPath(new URL("./index.html", import.meta.url)), "utf8");
   const log: Progress[] = [];
-  const remote = await createRemote<ShortbreadWorker>({
-    workerCount: os.cpus().length,
+  const workerCount = selectWorkerCount({
+    hardwareConcurrency: availableParallelism(),
+    reserveCores: 1,
+  });
+  const remote = await createShortbreadRemote({
+    workerCount,
     workerUrl: new URL("./shortbread.worker.ts", import.meta.url),
     onProgress: (event) => log.push(event),
   });
@@ -30,7 +34,7 @@ export async function startShortbreadServer() {
   const state = { dataset, filename, log };
   const app = createShortbreadServerApp({ remote, state, indexHtml, port });
 
-  console.log(`Number of workers available: ${os.cpus().length}`);
+  console.log(`Number of workers available: ${remote.workerCount}`);
   serve({ fetch: app.fetch, port }, (info) => {
     console.log(`Shortbread vector tile server running at http://localhost:${info.port}`);
     console.log("Osmix initialized with Shortbread encoder");

--- a/apps/shortbread/shortbread.worker.ts
+++ b/apps/shortbread/shortbread.worker.ts
@@ -5,16 +5,22 @@
  * by subclassing and adding new methods.
  */
 
-import { ShortbreadVtEncoder } from "@osmix/shortbread";
+import { inspectBackingBuffers } from "@osmix/shared/backing-buffers";
+import {
+  ShortbreadFeatureIndex,
+  type ShortbreadFeatureIndexTransferables,
+  ShortbreadVtEncoder,
+} from "@osmix/shortbread";
 import type { Tile } from "@osmix/types";
 import * as Comlink from "comlink";
-import { OsmixWorker } from "osmix";
+import { exposeOsmixWorker, OsmixWorker } from "osmix";
 
 /**
  * Extended worker class that adds Shortbread vector tile generation.
  */
 export class ShortbreadWorker extends OsmixWorker {
   private encoders: Map<string, ShortbreadVtEncoder> = new Map();
+  private featureIndexes = new Map<string, ShortbreadFeatureIndex>();
 
   /**
    * Get or create a ShortbreadVtEncoder for the given Osm instance ID.
@@ -23,10 +29,57 @@ export class ShortbreadWorker extends OsmixWorker {
     let encoder = this.encoders.get(id);
     if (!encoder) {
       const osmix = this.get(id);
-      encoder = new ShortbreadVtEncoder(osmix);
+      encoder = new ShortbreadVtEncoder(osmix, {
+        featureIndex: this.featureIndexes.get(id),
+      });
       this.encoders.set(id, encoder);
     }
     return encoder;
+  }
+
+  /** Build the shared Shortbread feature index on the control worker. */
+  buildShortbreadFeatureIndex(id: string): ShortbreadFeatureIndexTransferables {
+    const index = ShortbreadFeatureIndex.build(this.get(id));
+    this.featureIndexes.set(id, index);
+    this.encoders.delete(id);
+    return index.transferables();
+  }
+
+  /** Build and retain an index without cloning its buffers back to the caller. */
+  buildShortbreadFeatureIndexInPlace(id: string): number {
+    const index = ShortbreadFeatureIndex.build(this.get(id));
+    this.featureIndexes.set(id, index);
+    this.encoders.delete(id);
+    return index.size;
+  }
+
+  /** Install a previously-built shared feature index in this worker. */
+  setShortbreadFeatureIndex(id: string, transferables: ShortbreadFeatureIndexTransferables): void {
+    this.featureIndexes.set(id, ShortbreadFeatureIndex.fromTransferables(transferables));
+    this.encoders.delete(id);
+  }
+
+  /** Return lightweight diagnostics without cloning index contents. */
+  getShortbreadFeatureIndexInfo(id: string): {
+    datasetArrayBufferCount: number;
+    datasetSharedBufferCount: number;
+    bufferCount: number;
+    sharedBufferCount: number;
+    size: number;
+  } | null {
+    const index = this.featureIndexes.get(id);
+    if (!index) return null;
+    const buffers = index.backingBuffers();
+    const dataset = inspectBackingBuffers(this.getOsmBuffers(id));
+    return {
+      datasetArrayBufferCount: dataset.arrayBuffers,
+      datasetSharedBufferCount: dataset.shared,
+      bufferCount: buffers.length,
+      sharedBufferCount: buffers.filter(
+        (buffer) => typeof SharedArrayBuffer !== "undefined" && buffer instanceof SharedArrayBuffer,
+      ).length,
+      size: index.size,
+    };
   }
 
   /**
@@ -52,9 +105,10 @@ export class ShortbreadWorker extends OsmixWorker {
    */
   override delete(id: string) {
     this.encoders.delete(id);
+    this.featureIndexes.delete(id);
     super.delete(id);
   }
 }
 
-// Expose the extended worker
-Comlink.expose(new ShortbreadWorker());
+// Expose the extended worker in either a Web Worker or Node worker thread.
+void exposeOsmixWorker(new ShortbreadWorker());

--- a/apps/shortbread/test/regional-stress.ts
+++ b/apps/shortbread/test/regional-stress.ts
@@ -1,0 +1,104 @@
+import { createReadStream } from "node:fs";
+import { availableParallelism } from "node:os";
+import { Readable } from "node:stream";
+
+import type { Tile } from "@osmix/types";
+import { selectWorkerCount } from "osmix";
+
+import { createShortbreadRemote } from "../remote.ts";
+
+const HEARTBEAT_MS = 25;
+const MAX_MAIN_THREAD_STALL_MS = 250;
+const ZOOM = 12;
+
+function centerTile(bbox: readonly number[]): Tile {
+  const longitude = (bbox[0]! + bbox[2]!) / 2;
+  const latitude = Math.max(-85.051_129, Math.min(85.051_129, (bbox[1]! + bbox[3]!) / 2));
+  const scale = 2 ** ZOOM;
+  const x = Math.floor(((longitude + 180) / 360) * scale);
+  const radians = (latitude * Math.PI) / 180;
+  const y = Math.floor(
+    ((1 - Math.log(Math.tan(radians) + 1 / Math.cos(radians)) / Math.PI) / 2) * scale,
+  );
+  return [x, y, ZOOM];
+}
+
+const filePath = process.env["OSMIX_SHORTBREAD_STRESS_PBF"];
+if (!filePath) {
+  console.log("Set OSMIX_SHORTBREAD_STRESS_PBF to run the Node Shortbread stress harness.");
+  process.exit(0);
+}
+
+const workerCount = selectWorkerCount({
+  hardwareConcurrency: availableParallelism(),
+  reserveCores: 1,
+  maxWorkers: 4,
+});
+let previousHeartbeat = performance.now();
+let maxMainThreadStallMs = 0;
+let peakRssBytes = process.memoryUsage.rss();
+const heartbeat = setInterval(() => {
+  const now = performance.now();
+  maxMainThreadStallMs = Math.max(maxMainThreadStallMs, now - previousHeartbeat - HEARTBEAT_MS);
+  previousHeartbeat = now;
+  peakRssBytes = Math.max(peakRssBytes, process.memoryUsage.rss());
+}, HEARTBEAT_MS);
+
+const remote = await createShortbreadRemote({
+  workerCount,
+  workerUrl: new URL("../shortbread.worker.ts", import.meta.url),
+});
+try {
+  const loadStartedAt = performance.now();
+  const dataset = await remote.fromPbf(
+    Readable.toWeb(createReadStream(filePath)) as ReadableStream<Uint8Array>,
+    { id: "regional-shortbread-stress" },
+  );
+  const loadMs = performance.now() - loadStartedAt;
+  const [centerX, centerY] = centerTile(dataset.bbox);
+  const tiles: Tile[] = [];
+  for (let y = centerY - 2; y <= centerY + 1; y++) {
+    for (let x = centerX - 2; x <= centerX + 1; x++) tiles.push([x, y, ZOOM]);
+  }
+  const tileStartedAt = performance.now();
+  const byteLengths = await Promise.all(
+    tiles.map((tile) =>
+      remote.runWithWorker(
+        async (worker) => (await worker.getShortbreadTile(dataset.id, tile)).byteLength,
+        { lane: "compute", retry: "once" },
+      ),
+    ),
+  );
+  const tileMs = performance.now() - tileStartedAt;
+  const indexInfo = await remote.getFeatureIndexDiagnostics(dataset.id);
+
+  if (maxMainThreadStallMs > MAX_MAIN_THREAD_STALL_MS) {
+    throw Error(`Main thread stalled for ${maxMainThreadStallMs.toFixed(1)} ms`);
+  }
+  if (indexInfo.some((info) => !info || info.sharedBufferCount !== info.bufferCount)) {
+    throw Error("Shortbread feature-index buffers were not shared across workers");
+  }
+  if (
+    indexInfo.some(
+      (info) => !info || info.datasetArrayBufferCount !== 0 || info.datasetSharedBufferCount === 0,
+    )
+  ) {
+    throw Error("OSM dataset buffers were duplicated instead of shared across workers");
+  }
+
+  console.log(
+    JSON.stringify({
+      byteLengths,
+      filePath,
+      indexSize: indexInfo[0]?.size ?? 0,
+      loadMs: Math.round(loadMs),
+      maxMainThreadStallMs: Math.round(maxMainThreadStallMs),
+      peakRssBytes,
+      tileMs: Math.round(tileMs),
+      workerCount,
+    }),
+  );
+} finally {
+  clearInterval(heartbeat);
+  remote[Symbol.dispose]();
+}

--- a/apps/shortbread/test/server.test.ts
+++ b/apps/shortbread/test/server.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
 import { test } from "node:test";
 
 import { Osm } from "@osmix/core";
@@ -8,27 +9,44 @@ import {
   type ShortbreadServerDataset,
   type ShortbreadServerRemote,
 } from "../app.ts";
+import { createShortbreadRemote } from "../remote.ts";
 
 function createDataset(): ShortbreadServerDataset {
+  const info = new Osm({ id: "fixture" }).info();
   return {
-    id: "fixture",
+    ...info,
     isReady: async () => true,
-    get: async () => new Osm({ id: "fixture" }),
     delete: async () => {},
-  } as ShortbreadServerDataset;
+  };
 }
 
-function createRemote(dataset: ShortbreadServerDataset): ShortbreadServerRemote {
+interface RecordedRunOptions {
+  lane?: string;
+  retry?: string;
+  signal?: AbortSignal;
+}
+
+function createRemote(
+  dataset: ShortbreadServerDataset,
+  onRun?: (options: RecordedRunOptions) => void,
+): ShortbreadServerRemote {
   return {
     fromPbf: async () => dataset,
-    getWorker: () => ({ getShortbreadTile: async () => new ArrayBuffer(3) }),
+    runWithWorker: async <R>(
+      task: (worker: never, index: number) => Promise<R> | R,
+      options: RecordedRunOptions,
+    ) => {
+      onRun?.(options);
+      return task({ getShortbreadTile: async () => new ArrayBuffer(3) } as never, 0);
+    },
   } as unknown as ShortbreadServerRemote;
 }
 
 void test("shortbread server app serves readiness and tiles without opening a port", async () => {
   const dataset = createDataset();
+  const runs: RecordedRunOptions[] = [];
   const app = createShortbreadServerApp({
-    remote: createRemote(dataset),
+    remote: createRemote(dataset, (options) => runs.push(options)),
     state: { dataset, filename: "fixture.pbf", log: [] },
     indexHtml: "<html>fixture</html>",
     port: 3001,
@@ -42,18 +60,20 @@ void test("shortbread server app serves readiness and tiles without opening a po
   assert.equal(tile.status, 200);
   assert.equal(tile.headers.get("content-type"), "application/vnd.mapbox-vector-tile");
   assert.equal((await tile.arrayBuffer()).byteLength, 3);
+  assert.equal(runs.length, 1);
+  assert.equal(runs[0]?.lane, "compute");
+  assert.equal(runs[0]?.retry, "once");
+  assert.ok(runs[0]?.signal instanceof AbortSignal);
 });
 
 void test("shortbread server app turns tile failures into a useful response", async () => {
   const dataset = createDataset();
-  const remote = createRemote(dataset) as ShortbreadServerRemote & {
-    getWorker: () => { getShortbreadTile: () => Promise<ArrayBuffer> };
-  };
-  remote.getWorker = () => ({
-    getShortbreadTile: async () => {
+  const remote = {
+    ...createRemote(dataset),
+    runWithWorker: async () => {
       throw Error("fixture tile failure");
     },
-  });
+  } as unknown as ShortbreadServerRemote;
   const app = createShortbreadServerApp({
     remote,
     state: { dataset, filename: "fixture.pbf", log: [] },
@@ -75,3 +95,41 @@ void test("shortbread server app turns tile failures into a useful response", as
     message: "fixture tile failure",
   });
 });
+
+void test(
+  "shortbread remote shares one indexed dataset across Node worker threads",
+  { timeout: 120_000 },
+  async () => {
+    const remote = await createShortbreadRemote({
+      workerCount: 2,
+      workerUrl: new URL("../shortbread.worker.ts", import.meta.url),
+    });
+    try {
+      const data = await readFile(new URL("../../../fixtures/monaco.pbf", import.meta.url));
+      const dataset = await remote.fromPbf(data, { id: "node-shortbread-monaco" });
+      const [controlInfo, computeInfo, controlTile, computeTile] = await Promise.all([
+        remote.runWithWorker((worker) => worker.getShortbreadFeatureIndexInfo(dataset.id), {
+          lane: "control",
+        }),
+        remote.runWithWorker((worker) => worker.getShortbreadFeatureIndexInfo(dataset.id), {
+          lane: "compute",
+        }),
+        remote.runWithWorker((worker) => worker.getShortbreadTile(dataset.id, [17059, 11948, 15]), {
+          lane: "control",
+        }),
+        remote.runWithWorker((worker) => worker.getShortbreadTile(dataset.id, [17059, 11948, 15]), {
+          lane: "compute",
+        }),
+      ]);
+
+      assert.ok(controlInfo);
+      assert.deepEqual(computeInfo, controlInfo);
+      assert.ok(controlInfo.size > 0);
+      assert.equal(controlInfo.sharedBufferCount, controlInfo.bufferCount);
+      assert.ok(controlTile.byteLength > 0);
+      assert.equal(computeTile.byteLength, controlTile.byteLength);
+    } finally {
+      remote[Symbol.dispose]();
+    }
+  },
+);

--- a/packages/core/src/tags.ts
+++ b/packages/core/src/tags.ts
@@ -225,7 +225,12 @@ export class Tags {
    * Get all entity indexes that have a specific tag key.
    */
   hasKey(keyIndex: number): number[] {
-    if (keyIndex < 0) return [];
+    if (
+      keyIndex < 0 ||
+      keyIndex >= this.keyIndexStart.length ||
+      keyIndex >= this.keyIndexCount.length
+    )
+      return [];
     const start = this.keyIndexStart.at(keyIndex) ?? 0;
     const count = this.keyIndexCount.at(keyIndex) ?? 0;
     return Array.from(this.keyEntities.array.subarray(start, start + count));

--- a/packages/core/test/tags-search.test.ts
+++ b/packages/core/test/tags-search.test.ts
@@ -35,6 +35,19 @@ describe("Tags.search on Nodes", () => {
     const none = nodes.search("highway");
     expect(none).toEqual([]);
   });
+
+  it("returns no matches for a shared string-table key absent from the collection", () => {
+    const st = new StringTable();
+    const nodes = new Nodes(st);
+    nodes.addNode({ id: 1, lon: -1, lat: 1, tags: { curb: "yes" } });
+    nodes.buildIndex();
+
+    const ways = new Ways(st, nodes);
+    ways.addWay({ id: 10, refs: [1], tags: { highway: "residential" } });
+    ways.buildIndex();
+
+    expect(nodes.search("highway")).toEqual([]);
+  });
 });
 
 describe("Tags.search on Ways", () => {

--- a/packages/osmix/README.md
+++ b/packages/osmix/README.md
@@ -54,7 +54,7 @@ before creating a remote:
 import { createRemote, getOsmixCapabilities } from "osmix";
 
 console.log(getOsmixCapabilities());
-// { webWorkers: true, canShareArrayBuffers: false, maxWorkers: 1, recommendedMode: "single-worker", ... }
+// { workerRuntime: "web", canShareArrayBuffers: false, maxWorkers: 1, recommendedMode: "single-worker", ... }
 
 using remote = await createRemote();
 console.log(remote.mode, remote.workerCount); // "single-worker", 1
@@ -62,12 +62,15 @@ console.log(remote.mode, remote.workerCount); // "single-worker", 1
 
 #### Environment support
 
-| Environment                                       | Mode            | Behavior                                                           |
-| ------------------------------------------------- | --------------- | ------------------------------------------------------------------ |
-| Browser, [cross-origin isolated][coi]             | `multi-worker`  | One worker per core; datasets shared via `SharedArrayBuffer`       |
-| Browser, not isolated (no COOP/COEP headers)      | `single-worker` | One worker; data is transferred/copied instead of shared           |
-| No Web Workers (Node, restricted runtimes)        | throws          | Pass `inProcess: true` or use the main-thread API (`fromPbf`, ...) |
-| `createRemote({ inProcess: true })` (Node, tests) | `in-process`    | Same API on the calling thread; long operations block that thread  |
+| Environment                                  | Mode            | Behavior                                                          |
+| -------------------------------------------- | --------------- | ----------------------------------------------------------------- |
+| Browser, [cross-origin isolated][coi]        | `multi-worker`  | One worker per core; datasets shared via `SharedArrayBuffer`      |
+| Browser, not isolated (no COOP/COEP headers) | `single-worker` | One worker; data is transferred/copied instead of shared          |
+| Bun                                          | Web Workers     | Runs off-thread; shared buffers enable multi-worker datasets      |
+| Deno                                         | Web Workers     | Runs off-thread; local worker entries require read permission     |
+| Node 20+                                     | worker threads  | Runs off-thread; shared buffers enable multi-worker datasets      |
+| No worker implementation                     | throws          | Pass `inProcess: true` or use the main-thread API                 |
+| `createRemote({ inProcess: true })`          | `in-process`    | Same API on the calling thread; long operations block that thread |
 
 [coi]: https://developer.mozilla.org/en-US/docs/Web/API/Window/crossOriginIsolated
 
@@ -150,15 +153,14 @@ The custom worker entry is schematic application wiring:
 
 ```ts schematic
 // my.worker.ts
-import { expose } from "comlink";
-import { OsmixWorker } from "osmix";
+import { exposeOsmixWorker, OsmixWorker } from "osmix";
 
 export class MyWorker extends OsmixWorker {
   countCafes(osmId: string) {
     return this.get(osmId).nodes.search("amenity", "cafe").length;
   }
 }
-expose(new MyWorker());
+void exposeOsmixWorker(new MyWorker());
 ```
 
 The matching Vite client wiring is also schematic:
@@ -171,8 +173,62 @@ import workerUrl from "./my.worker.ts?worker&url";
 const remote = await createRemote<MyWorker>({
   workerUrl: new URL(workerUrl, import.meta.url),
 });
-const cafes = await remote.getWorker().countCafes(osmId);
+const cafes = await remote.runWithWorker((worker) => worker.countCafes(osmId), {
+  lane: "compute",
+  retry: "once",
+});
 ```
+
+`runWithWorker()` reserves an available worker until the operation settles. Use
+the `control` lane for stateful sequences, and retry only read-only, replayable
+operations. `getWorker()` remains available for compatibility but does not
+participate in availability scheduling.
+
+Worker restart recovery never retains a second copy of input bytes. Shared
+datasets keep only their `SharedArrayBuffer` descriptors. In single-worker mode,
+datasets loaded from a `File` are replayed from that same file reference, and
+GeoParquet URLs or paths are reopened. Streams and raw buffers are one-shot
+sources: if their worker is lost, the next retry rejects with
+`OsmixDatasetLossError` instead of continuing against an empty worker. Custom
+`OsmixRemote` subclasses can implement `recoverDataset()` and call
+`registerDatasetForRecovery()` for application-owned durable sources such as
+IndexedDB or a filesystem path. Mutating operations are never retried.
+If a dataset transfer, rename, or deletion broadcast fails after only some
+workers may have committed it, the pool is disposed and later calls reject with
+`OsmixRemoteStateError` rather than reading divergent state.
+
+#### Low-level worker pools
+
+Applications with custom worker protocols can use the supported
+`osmix/worker-pool` entrypoint directly:
+
+```ts schematic
+import { createOsmixWorkerPool } from "osmix/worker-pool";
+import type { MyWorker } from "./my.worker.ts";
+
+const pool = await createOsmixWorkerPool<MyWorker>({
+  workerCount: 4,
+  workerUrl: new URL("./my.worker.js", import.meta.url),
+  restoreWorker: async (worker) => worker.restoreReadOnlyState(),
+});
+
+try {
+  const result = await pool.run((worker, workerIndex) => worker.read(workerIndex), {
+    priority: 10,
+    retry: "once",
+    signal: abortController.signal,
+  });
+} finally {
+  await pool.dispose();
+}
+```
+
+The pool provides stable priority/FIFO scheduling, worker affinity, bounded
+startup/restoration/operation timeouts, queued aborts, one restart per slot,
+opt-in retry-after-restart, and diagnostics. It does not know how to replicate
+application state; supply `restoreWorker` when restarted workers need datasets
+or derived indexes. A restoration error is preserved as the terminal slot error
+so queued work sees the actual cause.
 
 See [`MergeWorker`](../../apps/merge/src/workers/osm.worker.ts) for a real
 example that adds IndexedDB storage.
@@ -270,13 +326,17 @@ spec-compliant without staging everything in memory.
 
 ### Workers (OsmixRemote)
 
-- `createRemote(options?)` - Create worker pool manager.
+- `createRemote(options?)` - Create a browser, Bun, Deno, or Node worker pool manager.
   - `options.workerCount` - Number of workers (default: all cores when SABs are shareable, else 1).
   - `options.workerUrl` - Custom worker entry (see [Workers](#workers)).
-  - `options.inProcess` - Run on the calling thread (Node, tests).
+  - `options.inProcess` - Explicitly run on the calling thread (blocking; useful in tests).
+  - `options.restoreTimeoutMs` - Bound replacement-worker rehydration time.
+  - `options.workerRuntime` - Override automatic `"web" | "bun" | "deno" | "node"` selection.
 - `getOsmixCapabilities()` - Inspect runtime support (workers, SAB sharing, max workers, recommended mode).
 - `canShareArrayBuffers()` - Whether `SharedArrayBuffer`s can be posted between threads.
 - `remote.mode` - Selected mode: `"multi-worker" | "single-worker" | "in-process"`.
+- `await remote.dispose()` - Await worker shutdown; also available through `Symbol.asyncDispose`.
+- `remote.runWithWorker(task, options?)` - Lease a managed `any`, `control`, or `compute` lane.
 - `remote.fromPbf(data, options?)` - Load in worker.
 - `remote.fromGeoJSON(data, options?)` - Load in worker.
 - `remote.getVectorTile(osmId, tile)` - Generate MVT in worker.

--- a/packages/osmix/package.json
+++ b/packages/osmix/package.json
@@ -12,7 +12,8 @@
   "main": "./src/index.ts",
   "exports": {
     ".": "./src/index.ts",
-    "./worker": "./src/osmix.worker.ts"
+    "./worker": "./src/osmix.worker.ts",
+    "./worker-pool": "./src/worker-pool.ts"
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json",

--- a/packages/osmix/src/capabilities.ts
+++ b/packages/osmix/src/capabilities.ts
@@ -12,16 +12,31 @@ import { supportsReadableStreamTransfer } from "./utils.ts";
 
 /**
  * How an `OsmixRemote` runs its workload.
- * - `multi-worker`: a pool of Web Workers sharing datasets via `SharedArrayBuffer`.
- * - `single-worker`: one Web Worker; data is transferred/cloned instead of shared.
- * - `in-process`: no Web Worker; everything runs on the calling thread.
+ * - `multi-worker`: worker pool sharing datasets via `SharedArrayBuffer`.
+ * - `single-worker`: one browser, Bun, Deno, or Node worker.
+ * - `in-process`: no worker; everything runs on the calling thread.
  */
 export type OsmixMode = "multi-worker" | "single-worker" | "in-process";
 
+/** Worker implementation available in the current runtime. */
+export type WorkerRuntime = "web" | "bun" | "deno" | "node" | "none";
+
+/** Options for selecting a bounded worker count while reserving caller capacity. */
+export interface SelectWorkerCountOptions {
+  /** Available logical processors. Defaults to the current runtime capability. */
+  hardwareConcurrency?: number;
+  /** Logical processors to leave for the caller. Defaults to 0. */
+  reserveCores?: number;
+  /** Upper bound for the selected worker count. Defaults to no explicit bound. */
+  maxWorkers?: number;
+}
+
 /** Snapshot of the runtime capabilities that determine which `OsmixMode`s are available. */
 export interface OsmixCapabilities {
-  /** Web Workers are available (`typeof Worker !== "undefined"`). Always false in Node. */
+  /** The Web Worker API is available. Always false in Node. */
   webWorkers: boolean;
+  /** Worker runtime selected by Osmix (`worker_threads` in Node, Web Workers elsewhere). */
+  workerRuntime: WorkerRuntime;
   /** The `SharedArrayBuffer` constructor exists. */
   sharedArrayBuffer: boolean;
   /** `globalThis.crossOriginIsolated === true` (browser COOP/COEP signal). */
@@ -38,6 +53,43 @@ export interface OsmixCapabilities {
   recommendedMode: OsmixMode;
 }
 
+/** Detect the worker implementation available to Osmix. */
+export function getWorkerRuntime(): WorkerRuntime {
+  const bun = Reflect.get(globalThis, "Bun") as { version?: unknown } | undefined;
+  if (typeof bun?.version === "string") return "bun";
+
+  const deno = Reflect.get(globalThis, "Deno") as { version?: { deno?: unknown } } | undefined;
+  if (typeof deno?.version?.deno === "string") return "deno";
+
+  if (
+    typeof process !== "undefined" &&
+    process.release?.name === "node" &&
+    typeof process.versions?.node === "string"
+  ) {
+    return "node";
+  }
+  return typeof Worker !== "undefined" ? "web" : "none";
+}
+
+/**
+ * Select a worker count while reserving logical processors for the calling thread.
+ * Always returns at least one worker.
+ */
+export function selectWorkerCount({
+  hardwareConcurrency = getOsmixCapabilities().hardwareConcurrency,
+  reserveCores = 0,
+  maxWorkers = Number.POSITIVE_INFINITY,
+}: SelectWorkerCountOptions = {}): number {
+  const hardware = Number.isFinite(hardwareConcurrency)
+    ? Math.max(1, Math.floor(hardwareConcurrency))
+    : 1;
+  const reserve = Number.isFinite(reserveCores) ? Math.max(0, Math.floor(reserveCores)) : 0;
+  const maximum = Number.isFinite(maxWorkers)
+    ? Math.max(1, Math.floor(maxWorkers))
+    : Number.POSITIVE_INFINITY;
+  return Math.max(1, Math.min(maximum, hardware - reserve));
+}
+
 /**
  * Check whether `SharedArrayBuffer`s can be shared across threads.
  *
@@ -47,6 +99,7 @@ export interface OsmixCapabilities {
  */
 export function canShareArrayBuffers(): boolean {
   if (typeof SharedArrayBuffer === "undefined") return false;
+  if (getWorkerRuntime() === "node") return true;
   // Browsers gate postMessage of SharedArrayBuffers behind cross-origin isolation.
   if ("crossOriginIsolated" in globalThis) return globalThis.crossOriginIsolated === true;
   return true;
@@ -58,23 +111,22 @@ export function canShareArrayBuffers(): boolean {
  */
 export function getOsmixCapabilities(): OsmixCapabilities {
   const webWorkers = typeof Worker !== "undefined";
+  const workerRuntime = getWorkerRuntime();
   const sharedArrayBuffer = typeof SharedArrayBuffer !== "undefined";
   const crossOriginIsolated = globalThis.crossOriginIsolated === true;
   const canShare = canShareArrayBuffers();
   const hardwareConcurrency = globalThis.navigator?.hardwareConcurrency ?? 1;
-  const maxWorkers = webWorkers && canShare ? hardwareConcurrency : 1;
+  const maxWorkers = workerRuntime !== "none" && canShare ? hardwareConcurrency : 1;
   return {
     webWorkers,
+    workerRuntime,
     sharedArrayBuffer,
     crossOriginIsolated,
     canShareArrayBuffers: canShare,
     streamTransfer: supportsReadableStreamTransfer(),
     hardwareConcurrency,
     maxWorkers,
-    recommendedMode: webWorkers
-      ? maxWorkers > 1
-        ? "multi-worker"
-        : "single-worker"
-      : "in-process",
+    recommendedMode:
+      workerRuntime !== "none" ? (maxWorkers > 1 ? "multi-worker" : "single-worker") : "in-process",
   };
 }

--- a/packages/osmix/src/index.ts
+++ b/packages/osmix/src/index.ts
@@ -10,20 +10,48 @@ export {
   createRemote,
   detectFileType,
   OSM_FILE_TYPES,
+  OsmixDatasetLossError,
   OsmixRemote,
+  OsmixRemoteStateError,
   type OsmFileType,
   type OsmId,
   type OsmRemoteDataset,
+  type OsmixRunWithWorkerOptions,
   type OsmixRemoteOptions,
+  type OsmixWorkerLane,
 } from "./remote.ts";
 export { OsmixWorker, type RouteResult, type WaySegment } from "./worker.ts";
 export { drawToRasterTile, type DrawToRasterTileOptions } from "./raster.ts";
 export {
   canShareArrayBuffers,
   getOsmixCapabilities,
+  getWorkerRuntime,
+  selectWorkerCount,
   type OsmixCapabilities,
   type OsmixMode,
+  type SelectWorkerCountOptions,
+  type WorkerRuntime,
 } from "./capabilities.ts";
+export {
+  createOsmixWorkerConnection,
+  createOsmixWorkerPool,
+  defaultOsmixWorkerUrl,
+  exposeOsmixWorker,
+  OsmixWorkerPool,
+  OsmixWorkerPoolDisposedError,
+  OsmixWorkerTaskTimeoutError,
+  OsmixWorkerUnavailableError,
+  type CreateOsmixWorkerConnectionOptions,
+  type OsmixWorkerConnection,
+  type OsmixWorkerPingTarget,
+  type OsmixWorkerPoolDiagnostics,
+  type OsmixWorkerPoolOptions,
+  type OsmixWorkerPoolRunOptions,
+  type OsmixWorkerPoolTask,
+  type OsmixWorkerPoolWorkerDiagnostics,
+  type WorkerConnectionRuntime,
+  type WorkerTaskRetry,
+} from "./worker-pool.ts";
 export {
   collectTransferables,
   supportsReadableStreamTransfer,

--- a/packages/osmix/src/osmix.worker.ts
+++ b/packages/osmix/src/osmix.worker.ts
@@ -9,18 +9,16 @@
  * const remote = await createRemote()
  *
  * @example
- * // Custom worker - import from worker to avoid side effects
- * import { OsmixWorker } from "osmix"
- * import { expose } from "comlink"
+ * // Custom cross-runtime worker
+ * import { exposeOsmixWorker, OsmixWorker } from "osmix"
  *
  * class MyWorker extends OsmixWorker {
  *   myMethod() { ... }
  * }
- * expose(new MyWorker())
+ * void exposeOsmixWorker(new MyWorker())
  */
 
-import { expose } from "comlink";
-
+import { exposeOsmixWorker } from "./worker-runtime.ts";
 import { OsmixWorker } from "./worker.ts";
 
-expose(new OsmixWorker());
+void exposeOsmixWorker(new OsmixWorker());

--- a/packages/osmix/src/remote.ts
+++ b/packages/osmix/src/remote.ts
@@ -1,7 +1,7 @@
 /**
  * Worker-based remote API for OSM operations.
  *
- * OsmixRemote manages a pool of Web Workers and provides a high-level API
+ * OsmixRemote manages a pool of browser or Node workers and provides a high-level API
  * for loading, querying, and manipulating OSM data off the main thread.
  * Uses SharedArrayBuffer for efficient multi-worker data sharing when available.
  *
@@ -9,19 +9,38 @@
  */
 
 import type { OsmChangeTypes, OsmMergeOptions } from "@osmix/change";
-import { Osm, type OsmInfo, type OsmOptions } from "@osmix/core";
+import { Osm, type OsmInfo, type OsmOptions, type OsmTransferables } from "@osmix/core";
 import type { GeoParquetReadOptions } from "@osmix/geoparquet";
 import { type GtfsConversionOptions, isGtfsZip as isGtfsZipBytes } from "@osmix/gtfs";
 import { type OsmFromPbfOptions, toPbfStream } from "@osmix/load";
-import type { DefaultSpeeds, HighwayFilter, RouteOptions, RouteResult } from "@osmix/router";
+import type {
+  DefaultSpeeds,
+  HighwayFilter,
+  RouteOptions,
+  RouteResult,
+  RoutingGraphTransferables,
+} from "@osmix/router";
+import { inspectBackingBuffers } from "@osmix/shared/backing-buffers";
 import type { Progress } from "@osmix/shared/progress";
 import { streamToBytes } from "@osmix/shared/stream-to-bytes";
 import type { LonLat, OsmEntityType, Tile } from "@osmix/types";
 import * as Comlink from "comlink";
 
-import { canShareArrayBuffers, getOsmixCapabilities, type OsmixMode } from "./capabilities.ts";
+import {
+  canShareArrayBuffers,
+  getOsmixCapabilities,
+  type OsmixMode,
+  type WorkerRuntime,
+} from "./capabilities.ts";
 import type { DrawToRasterTileOptions } from "./raster.ts";
 import { supportsReadableStreamTransfer, transfer } from "./utils.ts";
+import {
+  createOsmixWorkerConnection,
+  createOsmixWorkerPool,
+  defaultOsmixWorkerUrl,
+  type OsmixWorkerPool,
+  type OsmixWorkerPoolDiagnostics,
+} from "./worker-pool.ts";
 import { OsmixWorker } from "./worker.ts";
 
 /** Identifier for an OSM dataset: string ID, Osm instance, or OsmInfo object. */
@@ -187,13 +206,69 @@ export interface OsmixRemoteOptions {
    * })
    */
   workerUrl?: URL;
+  /** Override automatic browser/Bun/Deno Web Worker or Node worker-thread selection. */
+  workerRuntime?: WorkerRuntime | "auto";
   /**
-   * Run the `OsmixWorker` on the calling thread instead of spawning a Web
+   * Run the `OsmixWorker` on the calling thread instead of spawning a
    * Worker. The API is identical but nothing runs in parallel and long
    * operations will block the current thread. This is the supported path for
-   * environments without Web Workers (e.g. Node, vitest).
+   * worker. This is useful for tests and explicitly blocking workflows.
    */
   inProcess?: boolean;
+  /** Maximum times a failed worker slot is recreated. Defaults to one. */
+  restartAttempts?: number;
+  /** Maximum time to rehydrate a replacement worker. Defaults to 10 seconds. */
+  restoreTimeoutMs?: number;
+}
+
+/** Worker lane used by {@link OsmixRemote.runWithWorker}. */
+export type OsmixWorkerLane = "any" | "compute" | "control";
+
+/** Scheduling controls for a managed custom-worker operation. */
+export interface OsmixRunWithWorkerOptions {
+  /** Cancel a queued operation. Running work must still cooperate to stop early. */
+  signal?: AbortSignal;
+  /** Prefer control worker zero, compute workers, or any available worker. */
+  lane?: OsmixWorkerLane;
+  /** Higher values run before lower-priority queued work; equal priorities stay FIFO. */
+  priority?: number;
+  /** Retry once after a successful worker restart and rehydration. Defaults to never. */
+  retry?: "never" | "once";
+  /** Reject and restart a worker when this operation exceeds the supplied duration. */
+  timeoutMs?: number;
+}
+
+/** A known worker dataset could not be reconstructed after its worker restarted. */
+export class OsmixDatasetLossError extends Error {
+  readonly datasetIds: readonly string[];
+  readonly workerIndex: number;
+  override readonly cause: unknown;
+
+  constructor(datasetIds: readonly string[], workerIndex: number, cause?: unknown) {
+    super(
+      `Worker ${workerIndex} restarted without a replayable source for dataset${
+        datasetIds.length === 1 ? "" : "s"
+      }: ${datasetIds.join(", ")}`,
+      { cause },
+    );
+    this.name = "OsmixDatasetLossError";
+    this.datasetIds = [...datasetIds];
+    this.workerIndex = workerIndex;
+    this.cause = cause;
+  }
+}
+
+/** A broadcast state change may have left worker slots with divergent state. */
+export class OsmixRemoteStateError extends Error {
+  readonly operation: string;
+  override readonly cause: unknown;
+
+  constructor(operation: string, cause: unknown) {
+    super(`The Osmix worker pool is unusable after a partial ${operation}`, { cause });
+    this.name = "OsmixRemoteStateError";
+    this.operation = operation;
+    this.cause = cause;
+  }
 }
 
 /**
@@ -201,10 +276,10 @@ export interface OsmixRemoteOptions {
  * Each worker receives the same progress listener proxy if provided.
  *
  * Mode selection (see `getOsmixCapabilities()` and `remote.mode`):
- * - Cross-origin isolated browsers get one worker per core, sharing datasets
+ * - Cross-origin isolated browsers, Bun, Deno, and Node get shared multi-worker datasets
  *   via `SharedArrayBuffer`.
  * - Browsers without `SharedArrayBuffer` sharing get a single worker.
- * - Environments without Web Workers throw; pass `inProcess: true` to run on
+ * - Environments without a worker implementation throw; pass `inProcess: true` to run on
  *   the calling thread instead.
  *
  * @example
@@ -222,11 +297,22 @@ export async function createRemote<T extends OsmixWorker = OsmixWorker>({
   workerCount,
   onProgress,
   workerUrl,
+  workerRuntime = "auto",
   inProcess = false,
+  restartAttempts = 1,
+  restoreTimeoutMs,
 }: OsmixRemoteOptions = {}): Promise<OsmixRemote<T>> {
   const remote = new OsmixRemote<T>();
   const count = workerCount ?? (inProcess ? 1 : getOsmixCapabilities().maxWorkers);
-  await remote.initializeWorkerPool(count, workerUrl, onProgress, inProcess);
+  await remote.initializeWorkerPool(
+    count,
+    workerUrl,
+    onProgress,
+    inProcess,
+    restartAttempts,
+    workerRuntime,
+    restoreTimeoutMs,
+  );
   return remote;
 }
 
@@ -237,45 +323,21 @@ export async function createRemote<T extends OsmixWorker = OsmixWorker>({
  * (published package in Node, CDNs, and unbundled ESM).
  */
 export function defaultWorkerUrl(): URL {
-  const ext = import.meta.url.endsWith(".ts") ? "ts" : "js";
-  return new URL(`./osmix.worker.${ext}`, import.meta.url);
+  return defaultOsmixWorkerUrl(import.meta.url);
 }
-
-const NO_WORKER_SUPPORT_MESSAGE =
-  "Web Workers are not available in this environment. Use the main-thread API " +
-  "(fromPbf, fromGeoJSON, ...) or pass { inProcess: true } to createRemote() to " +
-  "run on the calling thread.";
 
 type WorkerCleanup = () => void;
 
 const workerCleanup = new WeakMap<object, WorkerCleanup>();
 
-/**
- * Create an `OsmixWorker` that runs on the calling thread, connected through a
- * `MessageChannel` so it can be driven by the same Comlink RPC as a real
- * worker. Used for environments without Web Workers (e.g. Node, vitest).
- */
-function createInProcessOsmixWorker<T extends OsmixWorker = OsmixWorker>(): Comlink.Remote<T> {
-  const { port1, port2 } = new MessageChannel();
-  try {
-    Comlink.expose(new OsmixWorker(), port1);
-    const remote = Comlink.wrap<T>(port2);
-    workerCleanup.set(remote, () => {
-      port1.close();
-      port2.close();
-    });
-    return remote;
-  } catch (error) {
-    port1.close();
-    port2.close();
-    throw error;
-  }
+function hasOnlySharedBackingBuffers(value: unknown): boolean {
+  const inspection = inspectBackingBuffers(value);
+  return inspection.unique > 0 && inspection.arrayBuffers === 0;
 }
 
 /**
  * Create a single `OsmixWorker` instance wrapped with Comlink.
- * Spawns a new Web Worker and returns a proxy for cross-thread RPC.
- * Throws in environments without Web Worker support.
+ * Spawns a browser, Bun, or Deno Worker or a Node worker thread and returns a proxy.
  *
  * @param workerUrl - Optional URL to a custom worker file. If not provided,
  *                    uses the default `OsmixWorker`.
@@ -293,27 +355,11 @@ function createInProcessOsmixWorker<T extends OsmixWorker = OsmixWorker>(): Coml
 export async function createOsmixWorker<T extends OsmixWorker = OsmixWorker>(
   workerUrl?: URL,
 ): Promise<Comlink.Remote<T>> {
-  if (typeof Worker === "undefined") throw Error(NO_WORKER_SUPPORT_MESSAGE);
-
-  const worker = new Worker(workerUrl ?? defaultWorkerUrl(), { type: "module" });
-  try {
-    if (!workerUrl) {
-      worker.addEventListener("error", (event) => {
-        console.error(
-          "osmix: the default worker failed to start. Bundlers often cannot resolve " +
-            "the default worker URL; pass `workerUrl` to createRemote() using your " +
-            "bundler's worker pattern. See https://github.com/conveyal/osmix/tree/main/packages/osmix#workers",
-          event,
-        );
-      });
-    }
-    const remote = Comlink.wrap<T>(worker);
-    workerCleanup.set(remote, () => worker.terminate());
-    return remote;
-  } catch (error) {
-    worker.terminate();
-    throw error;
-  }
+  const connection = await createOsmixWorkerConnection<T>({
+    workerUrl: workerUrl ?? defaultWorkerUrl(),
+  });
+  workerCleanup.set(connection.remote, () => connection.terminate());
+  return connection.remote;
 }
 
 /**
@@ -330,10 +376,29 @@ export async function createOsmixWorker<T extends OsmixWorker = OsmixWorker>(
  * })
  * // remote.getWorker() returns Comlink.Remote<MyWorker>
  */
+interface ActiveChangesetState {
+  baseOsmId: string;
+  changeTypes: OsmChangeTypes[];
+  entityTypes: OsmEntityType[];
+  options: Partial<OsmMergeOptions>;
+  patchOsmId: string;
+}
+
+type DatasetRestorer<T extends OsmixWorker> = (
+  worker: Comlink.Remote<T>,
+  datasetId: string,
+) => Promise<unknown>;
+
 export class OsmixRemote<T extends OsmixWorker = OsmixWorker> {
-  private workers: Comlink.Remote<T>[] = [];
-  private changesetWorker: Comlink.Remote<T> | null = null;
+  private activeChangeset: ActiveChangesetState | null = null;
+  private readonly datasetRestorers = new Map<string, DatasetRestorer<T> | null>();
+  private readonly retainedDatasets = new Map<string, OsmTransferables>();
+  private readonly retainedRoutingGraphs = new Map<string, RoutingGraphTransferables>();
+  private onProgress: ((progress: Progress) => void) | undefined;
+  private disposal: Promise<void> | null = null;
   private poolMode: OsmixMode | null = null;
+  private terminalError: OsmixRemoteStateError | null = null;
+  private workerPool: OsmixWorkerPool<T> | null = null;
 
   /**
    * How this remote runs its workload: `multi-worker`, `single-worker`, or
@@ -346,7 +411,7 @@ export class OsmixRemote<T extends OsmixWorker = OsmixWorker> {
 
   /** Number of workers in the pool. */
   get workerCount(): number {
-    return this.workers.length;
+    return this.workerPool?.workerCount ?? 0;
   }
 
   /**
@@ -354,15 +419,18 @@ export class OsmixRemote<T extends OsmixWorker = OsmixWorker> {
    * - Use a custom worker by passing a worker URL.
    * - Pass a progress listener to receive updates during long-running operations.
    * - Multiple workers require `SharedArrayBuffer` sharing (see `getOsmixCapabilities()`).
-   * - Pass `inProcess: true` to run a single `OsmixWorker` on the calling thread
-   *   (environments without Web Workers, e.g. Node and vitest).
+   * - Pass `inProcess: true` to run a single `OsmixWorker` on the calling thread.
    */
   async initializeWorkerPool(
     workerCount: number,
     workerUrl?: URL,
     onProgress?: (progress: Progress) => void,
     inProcess = false,
+    restartAttempts = 1,
+    workerRuntime: WorkerRuntime | "auto" = "auto",
+    restoreTimeoutMs?: number,
   ) {
+    if (this.disposal) await this.disposal;
     if (workerCount < 1) throw Error("Worker count must be at least 1");
     if (workerCount > 1 && inProcess)
       throw Error("In-process mode runs on the calling thread and supports only one worker.");
@@ -375,38 +443,125 @@ export class OsmixRemote<T extends OsmixWorker = OsmixWorker> {
           "(Cross-Origin-Opener-Policy: same-origin, Cross-Origin-Embedder-Policy: require-corp) " +
           "or omit workerCount. See https://github.com/conveyal/osmix/tree/main/packages/osmix#enabling-multi-worker-mode",
       );
+    this.onProgress = onProgress;
+    this.terminalError = null;
     try {
-      for (let i = 0; i < workerCount; i++) {
-        const worker = inProcess
-          ? createInProcessOsmixWorker<T>()
-          : await createOsmixWorker<T>(workerUrl);
-        this.workers.push(worker);
-        if (onProgress) {
-          await worker.addProgressListener(Comlink.proxy(onProgress));
-        }
+      this.workerPool = await createOsmixWorkerPool<T>({
+        createInProcessWorker: () => new OsmixWorker() as T,
+        inProcess,
+        restartAttempts,
+        restoreTimeoutMs,
+        runtime: workerRuntime,
+        restoreWorker: (worker, index, attempt) => this.restorePoolWorker(worker, index, attempt),
+        workerCount,
+        workerUrl: inProcess ? undefined : (workerUrl ?? defaultWorkerUrl()),
+      });
+      if (onProgress) {
+        await this.workerPool.broadcast((worker) =>
+          worker.addProgressListener(Comlink.proxy(onProgress)),
+        );
       }
     } catch (error) {
       this.terminate();
       throw error;
     }
-    this.changesetWorker = this.workers[0]!;
     this.poolMode = inProcess ? "in-process" : workerCount > 1 ? "multi-worker" : "single-worker";
   }
 
   /**
-   * Select the next available worker in a round-robin fashion.
-   * Cycles workers to balance load across the pool.
+   * Run a custom operation on a managed worker. The worker remains leased until
+   * the returned promise settles, allowing the pool to dispatch by availability.
    */
-  private nextWorker() {
-    const nextWorker = this.workers.shift();
-    if (!nextWorker) throw Error("No worker available");
-    this.workers.push(nextWorker);
-    return nextWorker;
+  runWithWorker<R>(
+    task: (worker: Comlink.Remote<T>, index: number) => R | Promise<R>,
+    options: OsmixRunWithWorkerOptions = {},
+  ): Promise<R> {
+    if (this.terminalError) return Promise.reject(this.terminalError);
+    const pool = this.getPool();
+    const { lane = "any", ...runOptions } = options;
+    const allIndexes = pool.workerIndexes;
+    const eligibleWorkerIndexes =
+      lane === "control"
+        ? [allIndexes[0]!]
+        : lane === "compute" && allIndexes.length > 1
+          ? allIndexes.slice(1)
+          : allIndexes;
+    return pool.run(task, { ...runOptions, eligibleWorkerIndexes });
+  }
+
+  /** Run an operation on every worker while respecting existing leases. */
+  protected broadcastToWorkers<R>(
+    task: (worker: Comlink.Remote<T>, index: number) => R | Promise<R>,
+    options: Omit<OsmixRunWithWorkerOptions, "lane"> = {},
+  ): Promise<R[]> {
+    return this.getPool().broadcast(task, options);
   }
 
   /**
-   * Get a worker proxy for calling custom methods on extended workers.
-   * Returns the next worker in the pool using round-robin selection.
+   * Broadcast state that must agree across every selected worker. A final
+   * failure is terminal because the caller cannot know which slots committed.
+   */
+  protected async broadcastStateChange<R>(
+    operation: string,
+    task: (worker: Comlink.Remote<T>, index: number) => R | Promise<R>,
+    options: {
+      eligibleWorkerIndexes?: readonly number[];
+      retry?: "never" | "once";
+    } = {},
+  ): Promise<R[]> {
+    const pool = this.getPool();
+    try {
+      return await pool.broadcast(task, options);
+    } catch (cause) {
+      const error = new OsmixRemoteStateError(operation, cause);
+      this.terminalError = error;
+      void pool.dispose();
+      throw error;
+    }
+  }
+
+  /** Run an operation on one stable worker index while respecting its lease. */
+  protected runOnWorker<R>(
+    index: number,
+    task: (worker: Comlink.Remote<T>, index: number) => R | Promise<R>,
+    options: Omit<OsmixRunWithWorkerOptions, "lane"> = {},
+  ): Promise<R> {
+    return this.getPool().runOn(index, task, options);
+  }
+
+  /** Inspect the managed pool without exposing raw worker proxies. */
+  protected workerPoolDiagnostics(): OsmixWorkerPoolDiagnostics {
+    return this.getPool().diagnostics();
+  }
+
+  /** Stable worker indexes for subclass lane and broadcast policies. */
+  protected workerIndexes(): readonly number[] {
+    return this.getPool().workerIndexes;
+  }
+
+  /**
+   * Send an out-of-band cooperative signal without acquiring worker leases.
+   * This is intentionally limited to idempotent notifications such as generation
+   * cancellation that must be observed by an async RPC already running in a slot.
+   */
+  protected notifyWorkers(
+    task: (worker: Comlink.Remote<T>, index: number) => void | Promise<void>,
+    workerIndexes: readonly number[] = this.workerIndexes(),
+  ): void {
+    const pool = this.getPool();
+    for (const index of workerIndexes) {
+      try {
+        void Promise.resolve(task(pool.getUnmanagedWorker(index), index)).catch(() => undefined);
+      } catch {
+        // Notifications are best-effort; managed work surfaces slot failures.
+      }
+    }
+  }
+
+  /**
+   * Get an unmanaged worker proxy for backwards compatibility.
+   * @deprecated Use {@link runWithWorker} so busy workers, cancellation, and
+   * recovery are tracked by the pool.
    *
    * @example
    * class ShortbreadWorker extends OsmixWorker {
@@ -418,25 +573,136 @@ export class OsmixRemote<T extends OsmixWorker = OsmixWorker> {
    * const tile = await remote.getWorker().getShortbreadVectorTile(osmId, tile)
    */
   getWorker(): Comlink.Remote<T> {
-    return this.nextWorker();
+    return this.getPool().getUnmanagedWorker();
   }
 
+  /** Restore application-specific state after base datasets and graphs are present. */
+  protected async rehydrateWorker(
+    _worker: Comlink.Remote<T>,
+    _index: number,
+    _restartAttempt: number,
+  ): Promise<void> {}
+
   /**
-   * Retrieve the dedicated changeset worker.
-   * Changesets must always be handled by the same worker to maintain consistency.
+   * Restore a known dataset from an application-owned replayable source.
+   *
+   * Subclasses can use this for sources such as IndexedDB or a filesystem path
+   * without retaining a second copy of the dataset bytes in `OsmixRemote`.
+   * Return `true` after installing `datasetId` in `worker`; the base class still
+   * verifies that the dataset exists before making the slot available.
    */
-  private getChangesetWorker() {
-    if (!this.changesetWorker) throw Error("No changeset worker available");
-    return this.changesetWorker;
+  protected async recoverDataset(
+    _worker: Comlink.Remote<T>,
+    _datasetId: string,
+    _workerIndex: number,
+    _restartAttempt: number,
+  ): Promise<boolean> {
+    return false;
+  }
+
+  /** Mark an application-loaded dataset as known so restart recovery is verified. */
+  protected registerDatasetForRecovery(osmId: OsmId): void {
+    const id = this.getId(osmId);
+    if (!this.datasetRestorers.has(id)) this.datasetRestorers.set(id, null);
+  }
+
+  /** Forget application-owned recovery metadata when a dataset is intentionally removed. */
+  protected unregisterDatasetForRecovery(osmId: OsmId): void {
+    const id = this.getId(osmId);
+    this.datasetRestorers.delete(id);
+    this.retainedDatasets.delete(id);
+    this.retainedRoutingGraphs.delete(id);
+  }
+
+  /** Mark changed data as known but not reproducible from its original source. */
+  private markDatasetUnrecoverable(osmId: OsmId): void {
+    const id = this.getId(osmId);
+    this.datasetRestorers.set(id, null);
+    this.retainedDatasets.delete(id);
+    this.retainedRoutingGraphs.delete(id);
+  }
+
+  private getPool(): OsmixWorkerPool<T> {
+    if (this.terminalError) throw this.terminalError;
+    if (!this.workerPool) throw Error("No worker available");
+    return this.workerPool;
+  }
+
+  protected async restorePoolWorker(
+    worker: Comlink.Remote<T>,
+    index: number,
+    restartAttempt: number,
+  ): Promise<void> {
+    if (this.onProgress) {
+      await worker.addProgressListener(Comlink.proxy(this.onProgress));
+    }
+    for (const transferables of this.retainedDatasets.values()) {
+      await worker.transferIn(transferables);
+    }
+
+    const recoveryFailures = new Map<string, unknown>();
+    for (const [datasetId, restorer] of this.datasetRestorers) {
+      if (await worker.has(datasetId)) continue;
+      if (restorer) {
+        try {
+          await restorer(worker, datasetId);
+        } catch (error) {
+          recoveryFailures.set(datasetId, error);
+        }
+      }
+      if (await worker.has(datasetId)) continue;
+      try {
+        await this.recoverDataset(worker, datasetId, index, restartAttempt);
+      } catch (error) {
+        recoveryFailures.set(datasetId, error);
+      }
+    }
+
+    try {
+      await this.rehydrateWorker(worker, index, restartAttempt);
+    } catch (error) {
+      const missing = await this.findMissingDatasets(worker);
+      if (missing.length > 0) {
+        throw new OsmixDatasetLossError(missing, index, error);
+      }
+      throw error;
+    }
+
+    const missing = await this.findMissingDatasets(worker);
+    if (missing.length > 0) {
+      const cause = missing.map((id) => recoveryFailures.get(id)).find(Boolean);
+      throw new OsmixDatasetLossError(missing, index, cause);
+    }
+
+    for (const [osmId, transferables] of this.retainedRoutingGraphs) {
+      await worker.transferRoutingGraphIn(osmId, transferables);
+    }
+    if (index === 0 && this.activeChangeset) {
+      const state = this.activeChangeset;
+      await worker.generateChangeset(state.baseOsmId, state.patchOsmId, state.options);
+      await worker.setChangesetFilters(state.changeTypes, state.entityTypes);
+    }
+  }
+
+  private async findMissingDatasets(worker: Comlink.Remote<T>): Promise<string[]> {
+    const missing: string[] = [];
+    for (const datasetId of this.datasetRestorers.keys()) {
+      if (!(await worker.has(datasetId))) missing.push(datasetId);
+    }
+    return missing;
   }
 
   /**
    * Convert various input types into a transferable format suitable for posting to workers.
    * Falls back to converting streams to buffers if stream transfer is unsupported.
    */
+  private isReplayableFile(value: unknown): value is File {
+    return typeof File !== "undefined" && value instanceof File;
+  }
+
   private async getTransferableData(data: ArrayBufferLike | ReadableStream | Uint8Array | File) {
     if (data instanceof ArrayBuffer) return data;
-    if (data instanceof SharedArrayBuffer) return data;
+    if (typeof SharedArrayBuffer !== "undefined" && data instanceof SharedArrayBuffer) return data;
     if (data instanceof Uint8Array) {
       if (data.byteOffset === 0 && data.byteLength === data.buffer.byteLength) {
         return data.buffer;
@@ -447,7 +713,7 @@ export class OsmixRemote<T extends OsmixWorker = OsmixWorker> {
       if (supportsReadableStreamTransfer()) return data;
       return (await streamToBytes(data)).buffer;
     }
-    if (data instanceof File) {
+    if (this.isReplayableFile(data)) {
       if (supportsReadableStreamTransfer()) return data.stream();
       return data.arrayBuffer();
     }
@@ -459,10 +725,37 @@ export class OsmixRemote<T extends OsmixWorker = OsmixWorker> {
    * No-op if SharedArrayBuffer is unsupported (single-worker mode).
    */
   protected async populateOtherWorkers(worker: Comlink.Remote<OsmixWorker>, osmId: OsmId) {
-    if (this.workers.length <= 1) return;
-    if (!canShareArrayBuffers()) return;
+    const pool = this.getPool();
+    this.registerDatasetForRecovery(osmId);
+    if (pool.workerCount <= 1 && !canShareArrayBuffers()) return;
     const transferables = await worker.getOsmBuffers(this.getId(osmId));
-    await Promise.all(this.workers.map((worker) => worker.transferIn(transferables)));
+    const isShared = hasOnlySharedBackingBuffers(transferables);
+    if (pool.workerCount > 1 && !isShared) {
+      throw Error("Multiple workers require a SharedArrayBuffer-backed OSM dataset");
+    }
+    if (isShared) {
+      this.retainedDatasets.set(transferables.id, transferables);
+      // Shared descriptors are the recovery source. Do not also retain a File
+      // or URL that may reference the complete regional input.
+      this.datasetRestorers.set(transferables.id, null);
+    }
+    if (pool.workerCount <= 1) return;
+    await this.broadcastStateChange(
+      "dataset replication",
+      (target) => target.transferIn(transferables),
+      {
+        eligibleWorkerIndexes: pool.workerIndexes.slice(1),
+        retry: "once",
+      },
+    );
+  }
+
+  /** Replicate a control-worker dataset and retain its shared descriptors for recovery. */
+  protected async populateDatasetFromControl(osmId: OsmId): Promise<void> {
+    await this.runWithWorker((worker) => this.populateOtherWorkers(worker, osmId), {
+      lane: "control",
+      retry: "once",
+    });
   }
 
   private wrap(info: OsmInfo): OsmRemoteDataset<T> {
@@ -478,12 +771,24 @@ export class OsmixRemote<T extends OsmixWorker = OsmixWorker> {
     data: ArrayBufferLike | ReadableStream | Uint8Array | File,
     options: Partial<OsmFromPbfOptions> = {},
   ) {
-    const workers = this.workers.slice();
-    const worker0 = workers.shift()!;
-    const osmInfo = await worker0.fromPbf(
-      transfer({ data: await this.getTransferableData(data), options }),
+    const transferableData = await this.getTransferableData(data);
+    const osmInfo = await this.runWithWorker(
+      (worker) => worker.fromPbf(transfer({ data: transferableData, options })),
+      { lane: "control", retry: "never" },
     );
-    await this.populateOtherWorkers(worker0, osmInfo.id);
+    const replayOptions = { ...options };
+    this.datasetRestorers.set(
+      osmInfo.id,
+      this.isReplayableFile(data)
+        ? async (worker, datasetId) => {
+            const replayData = await this.getTransferableData(data);
+            return worker.fromPbf(
+              transfer({ data: replayData, options: { ...replayOptions, id: datasetId } }),
+            );
+          }
+        : null,
+    );
+    await this.populateDatasetFromControl(osmInfo.id);
     return this.wrap(osmInfo);
   }
 
@@ -493,8 +798,12 @@ export class OsmixRemote<T extends OsmixWorker = OsmixWorker> {
    */
   toPbfStream(osmId: OsmId, writeableStream: WritableStream<Uint8Array>) {
     if (!supportsReadableStreamTransfer()) throw Error("Stream transfer not supported");
-    return this.nextWorker().toPbfStream(
-      Comlink.transfer({ osmId: this.getId(osmId), writeableStream }, [writeableStream]),
+    return this.runWithWorker(
+      (worker) =>
+        worker.toPbfStream(
+          Comlink.transfer({ osmId: this.getId(osmId), writeableStream }, [writeableStream]),
+        ),
+      { lane: "any", retry: "never" },
     );
   }
 
@@ -503,7 +812,9 @@ export class OsmixRemote<T extends OsmixWorker = OsmixWorker> {
    * Returns the buffer transferred from the worker.
    */
   toPbfData(osmId: OsmId) {
-    return this.nextWorker().toPbf(this.getId(osmId));
+    return this.runWithWorker((worker) => worker.toPbf(this.getId(osmId)), {
+      retry: "once",
+    });
   }
 
   /**
@@ -524,15 +835,30 @@ export class OsmixRemote<T extends OsmixWorker = OsmixWorker> {
     data: ArrayBufferLike | ReadableStream | Uint8Array | File,
     options: Partial<OsmOptions> = {},
   ) {
-    const workers = this.workers.slice();
-    const worker0 = workers.shift()!;
-    const osmInfo = await worker0.fromGeoJSON(
-      transfer({
-        data: await this.getTransferableData(data),
-        options,
-      }),
+    const transferableData = await this.getTransferableData(data);
+    const osmInfo = await this.runWithWorker(
+      (worker) =>
+        worker.fromGeoJSON(
+          transfer({
+            data: transferableData,
+            options,
+          }),
+        ),
+      { lane: "control", retry: "never" },
     );
-    await this.populateOtherWorkers(worker0, osmInfo.id);
+    const replayOptions = { ...options };
+    this.datasetRestorers.set(
+      osmInfo.id,
+      this.isReplayableFile(data)
+        ? async (worker, datasetId) => {
+            const replayData = await this.getTransferableData(data);
+            return worker.fromGeoJSON(
+              transfer({ data: replayData, options: { ...replayOptions, id: datasetId } }),
+            );
+          }
+        : null,
+    );
+    await this.populateDatasetFromControl(osmInfo.id);
     return this.wrap(osmInfo);
   }
 
@@ -544,15 +870,30 @@ export class OsmixRemote<T extends OsmixWorker = OsmixWorker> {
     data: ArrayBufferLike | ReadableStream | Uint8Array | File,
     options: Partial<OsmOptions> = {},
   ) {
-    const workers = this.workers.slice();
-    const worker0 = workers.shift()!;
-    const osmInfo = await worker0.fromShapefile(
-      transfer({
-        data: await this.getTransferableData(data),
-        options,
-      }),
+    const transferableData = await this.getTransferableData(data);
+    const osmInfo = await this.runWithWorker(
+      (worker) =>
+        worker.fromShapefile(
+          transfer({
+            data: transferableData,
+            options,
+          }),
+        ),
+      { lane: "control", retry: "never" },
     );
-    await this.populateOtherWorkers(worker0, osmInfo.id);
+    const replayOptions = { ...options };
+    this.datasetRestorers.set(
+      osmInfo.id,
+      this.isReplayableFile(data)
+        ? async (worker, datasetId) => {
+            const replayData = await this.getTransferableData(data);
+            return worker.fromShapefile(
+              transfer({ data: replayData, options: { ...replayOptions, id: datasetId } }),
+            );
+          }
+        : null,
+    );
+    await this.populateDatasetFromControl(osmInfo.id);
     return this.wrap(osmInfo);
   }
 
@@ -565,16 +906,36 @@ export class OsmixRemote<T extends OsmixWorker = OsmixWorker> {
     options: Partial<OsmOptions> = {},
     gtfsOptions: GtfsConversionOptions = {},
   ) {
-    const workers = this.workers.slice();
-    const worker0 = workers.shift()!;
-    const osmInfo = await worker0.fromGtfs(
-      transfer({
-        data: await this.getTransferableData(data),
-        options,
-        gtfsOptions,
-      }),
+    const transferableData = await this.getTransferableData(data);
+    const osmInfo = await this.runWithWorker(
+      (worker) =>
+        worker.fromGtfs(
+          transfer({
+            data: transferableData,
+            options,
+            gtfsOptions,
+          }),
+        ),
+      { lane: "control", retry: "never" },
     );
-    await this.populateOtherWorkers(worker0, osmInfo.id);
+    const replayOptions = { ...options };
+    const replayGtfsOptions = { ...gtfsOptions };
+    this.datasetRestorers.set(
+      osmInfo.id,
+      this.isReplayableFile(data)
+        ? async (worker, datasetId) => {
+            const replayData = await this.getTransferableData(data);
+            return worker.fromGtfs(
+              transfer({
+                data: replayData,
+                options: { ...replayOptions, id: datasetId },
+                gtfsOptions: replayGtfsOptions,
+              }),
+            );
+          }
+        : null,
+    );
+    await this.populateDatasetFromControl(osmInfo.id);
     return this.wrap(osmInfo);
   }
 
@@ -672,17 +1033,44 @@ export class OsmixRemote<T extends OsmixWorker = OsmixWorker> {
     options: Partial<OsmOptions> = {},
     readOptions: GeoParquetReadOptions = {},
   ) {
-    const workers = this.workers.slice();
-    const worker0 = workers.shift()!;
     const transferableData = await this.getGeoParquetTransferableData(data);
-    const osmInfo = await worker0.fromGeoParquet(
-      transfer({
-        data: transferableData,
-        options,
-        readOptions,
-      }),
+    const osmInfo = await this.runWithWorker(
+      (worker) =>
+        worker.fromGeoParquet(
+          transfer({
+            data: transferableData,
+            options,
+            readOptions,
+          }),
+        ),
+      { lane: "control", retry: "never" },
     );
-    await this.populateOtherWorkers(worker0, osmInfo.id);
+    const replayOptions = { ...options };
+    const replayReadOptions = { ...readOptions };
+    const replayableSource =
+      typeof data === "string"
+        ? data
+        : data instanceof URL
+          ? new URL(data.href)
+          : this.isReplayableFile(data)
+            ? data
+            : null;
+    this.datasetRestorers.set(
+      osmInfo.id,
+      replayableSource
+        ? async (worker, datasetId) => {
+            const replayData = await this.getGeoParquetTransferableData(replayableSource);
+            return worker.fromGeoParquet(
+              transfer({
+                data: replayData,
+                options: { ...replayOptions, id: datasetId },
+                readOptions: replayReadOptions,
+              }),
+            );
+          }
+        : null,
+    );
+    await this.populateDatasetFromControl(osmInfo.id);
     return this.wrap(osmInfo);
   }
 
@@ -696,7 +1084,7 @@ export class OsmixRemote<T extends OsmixWorker = OsmixWorker> {
     if (typeof data === "string") return data;
     if (data instanceof URL) return data;
     if (data instanceof ArrayBuffer) return data;
-    if (data instanceof File) return data.arrayBuffer();
+    if (this.isReplayableFile(data)) return data.arrayBuffer();
     throw Error("Invalid GeoParquet data source");
   }
 
@@ -705,7 +1093,10 @@ export class OsmixRemote<T extends OsmixWorker = OsmixWorker> {
    * Useful for previewing metadata before committing to a full load.
    */
   async readHeader(data: ArrayBuffer | ReadableStream | Uint8Array | File) {
-    return this.nextWorker().readHeader(await this.getTransferableData(data));
+    const transferableData = await this.getTransferableData(data);
+    return this.runWithWorker((worker) => worker.readHeader(transferableData), {
+      retry: "never",
+    });
   }
 
   /**
@@ -723,14 +1114,17 @@ export class OsmixRemote<T extends OsmixWorker = OsmixWorker> {
    * Check if an Osm instance has completed index building and is ready for queries.
    */
   async isReady(osmId: OsmId) {
+    if (this.terminalError) throw this.terminalError;
     try {
-      await Promise.all(
-        this.workers.map(async (worker) => {
+      await this.getPool().broadcast(
+        async (worker) => {
           const isReady = await worker.isReady(this.getId(osmId));
           if (!isReady) throw Error("Osm instance is not ready");
-        }),
+        },
+        { retry: "once" },
       );
-    } catch {
+    } catch (error) {
+      if (error instanceof OsmixRemoteStateError) throw error;
       return false;
     }
     return true;
@@ -740,7 +1134,7 @@ export class OsmixRemote<T extends OsmixWorker = OsmixWorker> {
    * Check if an `Osm` instance exists in any worker.
    */
   has(osmId: OsmId) {
-    return this.nextWorker().has(this.getId(osmId));
+    return this.runWithWorker((worker) => worker.has(this.getId(osmId)), { retry: "once" });
   }
 
   /**
@@ -748,7 +1142,10 @@ export class OsmixRemote<T extends OsmixWorker = OsmixWorker> {
    * Useful for direct access when worker overhead is unnecessary.
    */
   async get(osmId: OsmId): Promise<Osm> {
-    const transferables = await this.nextWorker().getOsmBuffers(this.getId(osmId));
+    const transferables = await this.runWithWorker(
+      (worker) => worker.getOsmBuffers(this.getId(osmId)),
+      { retry: "once" },
+    );
     return new Osm(transferables);
   }
 
@@ -757,7 +1154,10 @@ export class OsmixRemote<T extends OsmixWorker = OsmixWorker> {
    * Useful for final cleanup or moving data out of worker context.
    */
   async transferOut(osmId: OsmId): Promise<Osm> {
-    const transferables = await this.nextWorker().transferOut(this.getId(osmId));
+    const transferables = await this.runWithWorker(
+      (worker) => worker.transferOut(this.getId(osmId)),
+      { lane: "control", retry: "never" },
+    );
     await this.delete(osmId);
     return new Osm(transferables);
   }
@@ -767,8 +1167,15 @@ export class OsmixRemote<T extends OsmixWorker = OsmixWorker> {
    * Distributes data across the worker pool for parallel operations.
    */
   async transferIn(osm: Osm): Promise<void> {
-    await Promise.all(
-      this.workers.map((worker) => worker.transferIn(transfer(osm.transferables()))),
+    const transferables = osm.transferables();
+    const isShared = hasOnlySharedBackingBuffers(transferables);
+    if (this.workerCount > 1 && !isShared) {
+      throw Error("Multiple workers require a SharedArrayBuffer-backed OSM dataset");
+    }
+    this.markDatasetUnrecoverable(transferables.id);
+    if (isShared) this.retainedDatasets.set(transferables.id, transferables);
+    await this.broadcastStateChange("dataset transfer", (worker) =>
+      worker.transferIn(transfer(transferables)),
     );
   }
 
@@ -776,7 +1183,15 @@ export class OsmixRemote<T extends OsmixWorker = OsmixWorker> {
    * Remove an `Osm` instance from all workers, freeing its memory.
    */
   async delete(osmId: OsmId): Promise<void> {
-    await Promise.all(this.workers.map((worker) => worker.delete(this.getId(osmId))));
+    const id = this.getId(osmId);
+    this.unregisterDatasetForRecovery(id);
+    if (
+      this.activeChangeset &&
+      (this.activeChangeset.baseOsmId === id || this.activeChangeset.patchOsmId === id)
+    ) {
+      this.activeChangeset = null;
+    }
+    await this.broadcastStateChange("dataset deletion", (worker) => worker.delete(id));
   }
 
   /**
@@ -788,14 +1203,29 @@ export class OsmixRemote<T extends OsmixWorker = OsmixWorker> {
     const from = this.getId(fromId);
     if (from === toId) return;
     // Get the osm from one worker, then re-register under the new ID
-    const worker0 = this.workers[0];
-    if (!worker0) throw Error("No worker available");
-    const transferables = await worker0.getOsmBuffers(from);
+    const transferables = await this.runWithWorker((worker) => worker.getOsmBuffers(from), {
+      lane: "control",
+      retry: "once",
+    });
     // Update the id in the transferables
     const updatedTransferables = { ...transferables, id: toId };
+    const restorer = this.datasetRestorers.get(from) ?? null;
+    this.unregisterDatasetForRecovery(from);
+    this.datasetRestorers.set(toId, restorer);
+    if (hasOnlySharedBackingBuffers(updatedTransferables)) {
+      this.retainedDatasets.set(toId, updatedTransferables);
+    }
+    if (
+      this.activeChangeset &&
+      (this.activeChangeset.baseOsmId === from || this.activeChangeset.patchOsmId === from)
+    ) {
+      this.activeChangeset = null;
+    }
     // Delete old entries and transfer in with new ID
-    await Promise.all(this.workers.map((w) => w.delete(from)));
-    await Promise.all(this.workers.map((w) => w.transferIn(updatedTransferables)));
+    await this.broadcastStateChange("dataset rename", async (worker) => {
+      await worker.delete(from);
+      await worker.transferIn(updatedTransferables);
+    });
   }
 
   /**
@@ -803,7 +1233,9 @@ export class OsmixRemote<T extends OsmixWorker = OsmixWorker> {
    * Delegates to an available worker for off-thread rendering.
    */
   getVectorTile(osmId: OsmId, tile: Tile) {
-    return this.nextWorker().getVectorTile(this.getId(osmId), tile);
+    return this.runWithWorker((worker) => worker.getVectorTile(this.getId(osmId), tile), {
+      retry: "once",
+    });
   }
 
   /**
@@ -811,7 +1243,9 @@ export class OsmixRemote<T extends OsmixWorker = OsmixWorker> {
    * Delegates to an available worker for off-thread rendering.
    */
   getRasterTile(osmId: OsmId, tile: Tile, opts?: DrawToRasterTileOptions) {
-    return this.nextWorker().getRasterTile(this.getId(osmId), tile, opts);
+    return this.runWithWorker((worker) => worker.getRasterTile(this.getId(osmId), tile, opts), {
+      retry: "once",
+    });
   }
 
   /**
@@ -819,43 +1253,63 @@ export class OsmixRemote<T extends OsmixWorker = OsmixWorker> {
    * Delegates to an available worker for off-thread search.
    */
   search(osmId: OsmId, key: string, val?: string) {
-    return this.nextWorker().search(this.getId(osmId), key, val);
+    return this.runWithWorker((worker) => worker.search(this.getId(osmId), key, val), {
+      retry: "once",
+    });
   }
 
   nodesSize(osmId: OsmId) {
-    return this.nextWorker().nodesSize(this.getId(osmId));
+    return this.runWithWorker((worker) => worker.nodesSize(this.getId(osmId)), {
+      retry: "once",
+    });
   }
 
   nodesGetById(osmId: OsmId, nodeId: number) {
-    return this.nextWorker().nodesGetById(this.getId(osmId), nodeId);
+    return this.runWithWorker((worker) => worker.nodesGetById(this.getId(osmId), nodeId), {
+      retry: "once",
+    });
   }
 
   nodesSearch(osmId: OsmId, key: string, val?: string) {
-    return this.nextWorker().nodesSearch(this.getId(osmId), key, val);
+    return this.runWithWorker((worker) => worker.nodesSearch(this.getId(osmId), key, val), {
+      retry: "once",
+    });
   }
 
   waysSize(osmId: OsmId) {
-    return this.nextWorker().waysSize(this.getId(osmId));
+    return this.runWithWorker((worker) => worker.waysSize(this.getId(osmId)), {
+      retry: "once",
+    });
   }
 
   waysGetById(osmId: OsmId, wayId: number) {
-    return this.nextWorker().waysGetById(this.getId(osmId), wayId);
+    return this.runWithWorker((worker) => worker.waysGetById(this.getId(osmId), wayId), {
+      retry: "once",
+    });
   }
 
   waysSearch(osmId: OsmId, key: string, val?: string) {
-    return this.nextWorker().waysSearch(this.getId(osmId), key, val);
+    return this.runWithWorker((worker) => worker.waysSearch(this.getId(osmId), key, val), {
+      retry: "once",
+    });
   }
 
   relationsSize(osmId: OsmId) {
-    return this.nextWorker().relationsSize(this.getId(osmId));
+    return this.runWithWorker((worker) => worker.relationsSize(this.getId(osmId)), {
+      retry: "once",
+    });
   }
 
   relationsGetById(osmId: OsmId, relationId: number) {
-    return this.nextWorker().relationsGetById(this.getId(osmId), relationId);
+    return this.runWithWorker((worker) => worker.relationsGetById(this.getId(osmId), relationId), {
+      retry: "once",
+    });
   }
 
   relationsSearch(osmId: OsmId, key: string, val?: string) {
-    return this.nextWorker().relationsSearch(this.getId(osmId), key, val);
+    return this.runWithWorker((worker) => worker.relationsSearch(this.getId(osmId), key, val), {
+      retry: "once",
+    });
   }
 
   // ---------------------------------------------------------------------------
@@ -870,11 +1324,19 @@ export class OsmixRemote<T extends OsmixWorker = OsmixWorker> {
     worker: Comlink.Remote<OsmixWorker>,
     osmId: OsmId,
   ) {
-    if (this.workers.length <= 1) return;
-    if (!canShareArrayBuffers()) return;
+    const pool = this.getPool();
+    if (pool.workerCount <= 1 && !canShareArrayBuffers()) return;
     const transferables = await worker.getRoutingGraphTransferables(this.getId(osmId));
-    await Promise.all(
-      this.workers.map((w) => w.transferRoutingGraphIn(this.getId(osmId), transferables)),
+    const isShared = hasOnlySharedBackingBuffers(transferables);
+    if (pool.workerCount > 1 && !isShared) {
+      throw Error("Multiple workers require a SharedArrayBuffer-backed routing graph");
+    }
+    if (isShared) this.retainedRoutingGraphs.set(this.getId(osmId), transferables);
+    if (pool.workerCount <= 1) return;
+    await this.broadcastStateChange(
+      "routing graph replication",
+      (target) => target.transferRoutingGraphIn(this.getId(osmId), transferables),
+      { eligibleWorkerIndexes: pool.workerIndexes.slice(1), retry: "once" },
     );
   }
 
@@ -888,17 +1350,23 @@ export class OsmixRemote<T extends OsmixWorker = OsmixWorker> {
    * @returns Graph statistics (node and edge counts).
    */
   async buildRoutingGraph(osmId: OsmId, filter?: HighwayFilter, defaultSpeeds?: DefaultSpeeds) {
-    const worker0 = this.nextWorker();
-    const stats = await worker0.buildRoutingGraph(this.getId(osmId), filter, defaultSpeeds);
-    await this.populateRoutingGraphToOtherWorkers(worker0, osmId);
-    return stats;
+    return this.runWithWorker(
+      async (worker) => {
+        const stats = await worker.buildRoutingGraph(this.getId(osmId), filter, defaultSpeeds);
+        await this.populateRoutingGraphToOtherWorkers(worker, osmId);
+        return stats;
+      },
+      { lane: "control", retry: "once" },
+    );
   }
 
   /**
    * Check if a routing graph exists for an Osm instance.
    */
   hasRoutingGraph(osmId: OsmId) {
-    return this.nextWorker().hasRoutingGraph(this.getId(osmId));
+    return this.runWithWorker((worker) => worker.hasRoutingGraph(this.getId(osmId)), {
+      retry: "once",
+    });
   }
 
   /**
@@ -911,7 +1379,10 @@ export class OsmixRemote<T extends OsmixWorker = OsmixWorker> {
    * @returns Nearest routable node info, or null if none found.
    */
   findNearestRoutableNode(osmId: OsmId, point: LonLat, maxDistanceM: number) {
-    return this.nextWorker().findNearestRoutableNode(this.getId(osmId), point, maxDistanceM);
+    return this.runWithWorker(
+      (worker) => worker.findNearestRoutableNode(this.getId(osmId), point, maxDistanceM),
+      { retry: "once" },
+    );
   }
 
   /**
@@ -930,7 +1401,10 @@ export class OsmixRemote<T extends OsmixWorker = OsmixWorker> {
     toIndex: number,
     options?: Partial<RouteOptions>,
   ): Promise<RouteResult | null> {
-    return this.nextWorker().route(this.getId(osmId), fromIndex, toIndex, options);
+    return this.runWithWorker(
+      (worker) => worker.route(this.getId(osmId), fromIndex, toIndex, options),
+      { retry: "once" },
+    );
   }
 
   // ---------------------------------------------------------------------------
@@ -943,9 +1417,12 @@ export class OsmixRemote<T extends OsmixWorker = OsmixWorker> {
    * Synchronizes the merged result across all workers.
    */
   async merge(baseOsmId: OsmId, patchOsmId: OsmId, options: Partial<OsmMergeOptions> = {}) {
-    const worker0 = this.nextWorker();
-    const osmId = await worker0.merge(this.getId(baseOsmId), this.getId(patchOsmId), options);
-    await this.populateOtherWorkers(worker0, osmId);
+    const osmId = await this.runWithWorker(
+      (worker) => worker.merge(this.getId(baseOsmId), this.getId(patchOsmId), options),
+      { lane: "control", retry: "never" },
+    );
+    this.markDatasetUnrecoverable(osmId);
+    await this.populateDatasetFromControl(osmId);
     await this.delete(patchOsmId);
     const merged = await this.get(osmId);
     return this.wrap(merged.info());
@@ -960,11 +1437,18 @@ export class OsmixRemote<T extends OsmixWorker = OsmixWorker> {
     patchOsmId: OsmId,
     options: Partial<OsmMergeOptions> = {},
   ) {
-    return this.getChangesetWorker().generateChangeset(
-      this.getId(baseOsmId),
-      this.getId(patchOsmId),
-      options,
+    const result = await this.runWithWorker(
+      (worker) => worker.generateChangeset(this.getId(baseOsmId), this.getId(patchOsmId), options),
+      { lane: "control", retry: "never" },
     );
+    this.activeChangeset = {
+      baseOsmId: this.getId(baseOsmId),
+      changeTypes: ["create", "modify", "delete"],
+      entityTypes: ["node", "way", "relation"],
+      options,
+      patchOsmId: this.getId(patchOsmId),
+    };
+    return result;
   }
 
   /**
@@ -972,9 +1456,13 @@ export class OsmixRemote<T extends OsmixWorker = OsmixWorker> {
    * Synchronizes the updated instance across all workers.
    */
   async applyChangesAndReplace(osmId: OsmId) {
-    const worker0 = this.getChangesetWorker();
-    await worker0.applyChangesAndReplace(this.getId(osmId));
-    await this.populateOtherWorkers(worker0, osmId);
+    await this.runWithWorker((worker) => worker.applyChangesAndReplace(this.getId(osmId)), {
+      lane: "control",
+      retry: "never",
+    });
+    this.markDatasetUnrecoverable(osmId);
+    await this.populateDatasetFromControl(osmId);
+    this.activeChangeset = null;
   }
 
   /**
@@ -982,34 +1470,59 @@ export class OsmixRemote<T extends OsmixWorker = OsmixWorker> {
    * Filters control which change types and entity types are visible when paginating.
    */
   setChangesetFilters(changeTypes: OsmChangeTypes[], entityTypes: OsmEntityType[]) {
-    void this.getChangesetWorker().setChangesetFilters(changeTypes, entityTypes);
+    if (this.activeChangeset) {
+      this.activeChangeset.changeTypes = [...changeTypes];
+      this.activeChangeset.entityTypes = [...entityTypes];
+    }
+    void this.runWithWorker((worker) => worker.setChangesetFilters(changeTypes, entityTypes), {
+      lane: "control",
+      retry: "never",
+    });
   }
 
   /**
    * Retrieve a paginated subset of the filtered changeset from the changeset worker.
    */
   getChangesetPage(osmId: OsmId, page: number, pageSize: number) {
-    return this.getChangesetWorker().getChangesetPage(this.getId(osmId), page, pageSize);
+    return this.runWithWorker(
+      (worker) => worker.getChangesetPage(this.getId(osmId), page, pageSize),
+      { lane: "control", retry: "once" },
+    );
   }
 
   /**
-   * Terminate all workers and release their resources.
+   * Terminate all workers, await their shutdown, and release their resources.
    */
-  terminate() {
-    for (const worker of this.workers) {
-      try {
-        worker[Comlink.releaseProxy]();
-      } finally {
-        workerCleanup.get(worker)?.();
-        workerCleanup.delete(worker);
-      }
-    }
-    this.workers = [];
-    this.changesetWorker = null;
+  dispose(): Promise<void> {
+    if (this.disposal) return this.disposal;
+    const pool = this.workerPool;
+    this.workerPool = null;
+    this.activeChangeset = null;
+    this.datasetRestorers.clear();
+    this.retainedDatasets.clear();
+    this.retainedRoutingGraphs.clear();
     this.poolMode = null;
+    this.terminalError = null;
+    this.disposal = (async () => {
+      try {
+        await pool?.dispose();
+      } finally {
+        this.disposal = null;
+      }
+    })();
+    return this.disposal;
+  }
+
+  /** Start worker shutdown without waiting. Prefer {@link dispose} when shutdown ordering matters. */
+  terminate(): void {
+    void this.dispose();
   }
 
   [Symbol.dispose]() {
     this.terminate();
+  }
+
+  [Symbol.asyncDispose](): Promise<void> {
+    return this.dispose();
   }
 }

--- a/packages/osmix/src/utils.ts
+++ b/packages/osmix/src/utils.ts
@@ -76,9 +76,10 @@ export function supportsReadableStreamTransfer(): boolean {
   // Require the basics first
   if (typeof ReadableStream === "undefined" || typeof MessageChannel === "undefined") return false;
 
-  const { port1 } = new MessageChannel();
+  const { port1, port2 } = new MessageChannel();
   try {
-    const rs = new ReadableStream(); // empty is fine for feature test
+    // A closed stream exercises transferability without leaving a live stream resource in Deno.
+    const rs = new ReadableStream({ start: (controller) => controller.close() });
     // If transferable streams are unsupported, this line throws a DataCloneError
     port1.postMessage(rs, [rs]);
     return true;
@@ -86,5 +87,6 @@ export function supportsReadableStreamTransfer(): boolean {
     return false;
   } finally {
     port1.close();
+    port2.close();
   }
 }

--- a/packages/osmix/src/worker-pool.ts
+++ b/packages/osmix/src/worker-pool.ts
@@ -1,0 +1,717 @@
+/** Availability-aware, fault-tolerant scheduling for Osmix workers. */
+
+import type * as Comlink from "comlink";
+
+import { getOsmixCapabilities, type WorkerRuntime } from "./capabilities.ts";
+import { createOsmixWorkerConnection, type OsmixWorkerConnection } from "./worker-runtime.ts";
+import { OsmixWorker } from "./worker.ts";
+
+export type MaybePromise<T> = T | PromiseLike<T>;
+export type WorkerTaskRetry = "never" | "once";
+
+/** Minimum interface required by the pool's startup probe. */
+export interface OsmixWorkerPingTarget {
+  ping(): true | Promise<true>;
+}
+
+/** A unit of work run against one managed worker proxy. */
+export type OsmixWorkerPoolTask<T extends OsmixWorkerPingTarget, R> = (
+  worker: Comlink.Remote<T>,
+  workerIndex: number,
+) => MaybePromise<R>;
+
+/** Per-operation scheduling and fault policy. */
+export interface OsmixWorkerPoolRunOptions {
+  /** Restrict execution to these worker indexes. Defaults to every worker. */
+  eligibleWorkerIndexes?: readonly number[];
+  /** Higher values run first. Equal priorities retain FIFO order. */
+  priority?: number;
+  /** Reject and restart the worker when execution exceeds this duration. */
+  timeoutMs?: number;
+  /** Retry once after a worker failure or timeout. Defaults to `never`. */
+  retry?: WorkerTaskRetry;
+  /** Remove queued work immediately; running RPCs settle in the background. */
+  signal?: AbortSignal;
+}
+
+export interface OsmixWorkerPoolWorkerDiagnostics {
+  index: number;
+  runtime: WorkerRuntime | "in-process";
+  state: "idle" | "busy" | "restarting" | "failed" | "disposed";
+  restartCount: number;
+}
+
+export interface OsmixWorkerPoolDiagnostics {
+  workerCount: number;
+  queuedTaskCount: number;
+  idleWorkerIndexes: number[];
+  busyWorkerIndexes: number[];
+  restartCount: number;
+  disposed: boolean;
+  workers: OsmixWorkerPoolWorkerDiagnostics[];
+}
+
+/** Construction and recovery hooks for a managed worker pool. */
+export interface OsmixWorkerPoolOptions<T extends OsmixWorkerPingTarget = OsmixWorker> {
+  /** Defaults to `getOsmixCapabilities().maxWorkers`. */
+  workerCount?: number;
+  /** Custom entrypoint for an `OsmixWorker` subclass. */
+  workerUrl?: URL;
+  /** Force a worker implementation; `auto` selects browser or Node workers. */
+  runtime?: WorkerRuntime | "auto";
+  /** Run one worker directly on the calling thread. */
+  inProcess?: boolean;
+  /** Construct a custom in-process implementation. */
+  createInProcessWorker?: () => T;
+  /** Deterministic/custom worker construction seam. */
+  createWorker?: (workerIndex: number) => MaybePromise<OsmixWorkerConnection<T>>;
+  /** Restore application state after a restarted worker passes its probe. */
+  restoreWorker?: (
+    worker: Comlink.Remote<T>,
+    workerIndex: number,
+    restartAttempt: number,
+  ) => MaybePromise<void>;
+  /** Restart attempts per slot. Defaults to 1. */
+  restartAttempts?: number;
+  /** Timeout for startup and restart probes. Defaults to 10 seconds. */
+  probeTimeoutMs?: number;
+  /** Timeout for restoring a restarted slot. Defaults to the probe timeout. */
+  restoreTimeoutMs?: number;
+}
+
+export class OsmixWorkerPoolDisposedError extends Error {
+  constructor() {
+    super("The Osmix worker pool has been disposed");
+    this.name = "OsmixWorkerPoolDisposedError";
+  }
+}
+
+export class OsmixWorkerUnavailableError extends Error {
+  readonly workerIndexes: readonly number[];
+
+  constructor(workerIndexes: readonly number[]) {
+    super(`No healthy worker is available among indexes: ${workerIndexes.join(", ")}`);
+    this.name = "OsmixWorkerUnavailableError";
+    this.workerIndexes = workerIndexes;
+  }
+}
+
+export class OsmixWorkerTaskTimeoutError extends Error {
+  readonly workerIndex: number;
+  readonly timeoutMs: number;
+
+  constructor(workerIndex: number, timeoutMs: number) {
+    super(`Worker ${workerIndex} operation timed out after ${timeoutMs} ms`);
+    this.name = "OsmixWorkerTaskTimeoutError";
+    this.workerIndex = workerIndex;
+    this.timeoutMs = timeoutMs;
+  }
+}
+
+class OsmixWorkerConnectionError extends Error {
+  override readonly cause: Error;
+
+  constructor(workerIndex: number, cause: Error) {
+    super(`Worker ${workerIndex} failed: ${cause.message}`);
+    this.name = "OsmixWorkerConnectionError";
+    this.cause = cause;
+  }
+}
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve(value: T): void;
+  reject(reason: unknown): void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+interface PoolJob<T extends OsmixWorkerPingTarget> {
+  sequence: number;
+  task: OsmixWorkerPoolTask<T, unknown>;
+  eligibleWorkerIndexes: readonly number[];
+  priority: number;
+  timeoutMs?: number;
+  retry: WorkerTaskRetry;
+  retryCount: number;
+  signal?: AbortSignal;
+  abortListener?: () => void;
+  callerSettled: boolean;
+  resolve(value: unknown): void;
+  reject(reason: unknown): void;
+}
+
+type SlotState = OsmixWorkerPoolWorkerDiagnostics["state"];
+
+interface WorkerSlot<T extends OsmixWorkerPingTarget> {
+  index: number;
+  connection: OsmixWorkerConnection<T>;
+  state: SlotState;
+  restartCount: number;
+  generation: number;
+  removeFailureListener: () => void;
+  failure: Deferred<never>;
+  failureError?: OsmixWorkerConnectionError;
+  terminalError?: unknown;
+  currentJob?: PoolJob<T>;
+  recovery?: Promise<void>;
+}
+
+const DEFAULT_PROBE_TIMEOUT_MS = 10_000;
+
+function validatePositiveInteger(value: number, label: string): void {
+  if (!Number.isInteger(value) || value < 1) throw new Error(`${label} must be at least 1`);
+}
+
+function validateNonNegativeInteger(value: number, label: string): void {
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error(`${label} must be a non-negative integer`);
+  }
+}
+
+function abortReason(signal: AbortSignal): unknown {
+  return signal.reason ?? new DOMException("The operation was aborted", "AbortError");
+}
+
+function withTimeout<T>(promise: PromiseLike<T>, timeoutMs: number, error: Error): Promise<T> {
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    return Promise.reject(new Error("timeoutMs must be greater than 0"));
+  }
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(error), timeoutMs);
+    Promise.resolve(promise).then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (reason) => {
+        clearTimeout(timer);
+        reject(reason);
+      },
+    );
+  });
+}
+
+/**
+ * Availability-aware worker scheduler. Construct with `createOsmixWorkerPool()`
+ * so startup probes finish before work can be queued.
+ */
+export class OsmixWorkerPool<T extends OsmixWorkerPingTarget = OsmixWorker>
+  implements Disposable, AsyncDisposable
+{
+  private readonly options: Required<
+    Pick<OsmixWorkerPoolOptions<T>, "restartAttempts" | "probeTimeoutMs" | "restoreTimeoutMs">
+  > &
+    Omit<OsmixWorkerPoolOptions<T>, "restartAttempts" | "probeTimeoutMs" | "restoreTimeoutMs">;
+  private readonly slots: WorkerSlot<T>[] = [];
+  private readonly queue: PoolJob<T>[] = [];
+  private sequence = 0;
+  private unmanagedWorkerCursor = 0;
+  private pumpScheduled = false;
+  private disposed = false;
+  private disposePromise?: Promise<void>;
+
+  private constructor(options: OsmixWorkerPoolOptions<T>) {
+    this.options = {
+      ...options,
+      restartAttempts: options.restartAttempts ?? 1,
+      probeTimeoutMs: options.probeTimeoutMs ?? DEFAULT_PROBE_TIMEOUT_MS,
+      restoreTimeoutMs:
+        options.restoreTimeoutMs ?? options.probeTimeoutMs ?? DEFAULT_PROBE_TIMEOUT_MS,
+    };
+  }
+
+  static async create<T extends OsmixWorkerPingTarget = OsmixWorker>(
+    options: OsmixWorkerPoolOptions<T> = {},
+  ): Promise<OsmixWorkerPool<T>> {
+    const pool = new OsmixWorkerPool(options);
+    await pool.initialize();
+    return pool;
+  }
+
+  /** Number of configured worker slots, including a failed slot. */
+  get workerCount(): number {
+    return this.slots.length;
+  }
+
+  /** Stable indexes for every configured worker slot. */
+  get workerIndexes(): readonly number[] {
+    return this.slots.map((slot) => slot.index);
+  }
+
+  private async initialize(): Promise<void> {
+    const workerCount = this.options.workerCount ?? getOsmixCapabilities().maxWorkers;
+    validatePositiveInteger(workerCount, "Worker count");
+    validateNonNegativeInteger(this.options.restartAttempts, "restartAttempts");
+    if (this.options.restartAttempts > 1) {
+      throw new Error("restartAttempts cannot exceed one");
+    }
+    if (this.options.inProcess && workerCount !== 1) {
+      throw new Error("In-process mode supports exactly one worker");
+    }
+    if (this.options.inProcess && this.options.workerUrl) {
+      throw new Error("workerUrl cannot be used in in-process mode");
+    }
+    const results = await Promise.allSettled(
+      Array.from({ length: workerCount }, (_, index) => this.createSlot(index, 0)),
+    );
+    for (const result of results) {
+      if (result.status === "fulfilled") this.slots.push(result.value);
+    }
+    const failure = results.find((result) => result.status === "rejected");
+    if (failure?.status === "rejected") {
+      await this.dispose();
+      throw failure.reason;
+    }
+  }
+
+  private async createConnection(index: number): Promise<OsmixWorkerConnection<T>> {
+    if (this.options.createWorker) return this.options.createWorker(index);
+    if (this.options.inProcess) {
+      const worker = this.options.createInProcessWorker?.() ?? (new OsmixWorker() as unknown as T);
+      return createOsmixWorkerConnection({ inProcessWorker: worker });
+    }
+    return createOsmixWorkerConnection<T>({
+      workerUrl: this.options.workerUrl,
+      runtime: this.options.runtime,
+    });
+  }
+
+  private async createSlot(index: number, restartCount: number): Promise<WorkerSlot<T>> {
+    const connection = await this.createConnection(index);
+    const slot: WorkerSlot<T> = {
+      index,
+      connection,
+      state: "restarting",
+      restartCount,
+      generation: 0,
+      removeFailureListener: () => undefined,
+      failure: deferred<never>(),
+    };
+    // A failure can occur while the slot is idle, with no operation racing this promise.
+    slot.failure.promise.catch(() => undefined);
+    this.attachFailureListener(slot);
+    try {
+      const ready = await withTimeout(
+        Promise.race([connection.remote.ping(), slot.failure.promise]),
+        this.options.probeTimeoutMs,
+        new OsmixWorkerTaskTimeoutError(index, this.options.probeTimeoutMs),
+      );
+      if (slot.failureError) throw slot.failureError;
+      if (ready !== true) throw new Error(`Worker ${index} returned an invalid probe response`);
+      if (restartCount > 0 && this.options.restoreWorker) {
+        await withTimeout(
+          Promise.race([
+            this.options.restoreWorker(connection.remote, index, restartCount),
+            slot.failure.promise,
+          ]),
+          this.options.restoreTimeoutMs,
+          new OsmixWorkerTaskTimeoutError(index, this.options.restoreTimeoutMs),
+        );
+      }
+      if (slot.failureError) throw slot.failureError;
+      slot.state = "idle";
+      return slot;
+    } catch (error) {
+      slot.removeFailureListener();
+      await connection.terminate();
+      throw error;
+    }
+  }
+
+  private attachFailureListener(slot: WorkerSlot<T>): void {
+    const generation = slot.generation;
+    slot.removeFailureListener = slot.connection.onFailure((error) => {
+      if (this.disposed || slot.generation !== generation) return;
+      const failureError = new OsmixWorkerConnectionError(slot.index, error);
+      slot.failureError = failureError;
+      slot.failure.reject(failureError);
+      if (slot.state === "idle") void this.recoverSlot(slot);
+    });
+  }
+
+  /** Queue one operation for the highest-priority eligible available worker. */
+  run<R>(task: OsmixWorkerPoolTask<T, R>, options: OsmixWorkerPoolRunOptions = {}): Promise<R> {
+    if (this.disposed) return Promise.reject(new OsmixWorkerPoolDisposedError());
+    const eligibleWorkerIndexes = this.normalizeEligibleIndexes(options.eligibleWorkerIndexes);
+    if (
+      options.timeoutMs !== undefined &&
+      (!Number.isFinite(options.timeoutMs) || options.timeoutMs <= 0)
+    ) {
+      return Promise.reject(new Error("timeoutMs must be greater than 0"));
+    }
+    if (options.signal?.aborted) return Promise.reject(abortReason(options.signal));
+
+    return new Promise<R>((resolve, reject) => {
+      const job: PoolJob<T> = {
+        sequence: this.sequence++,
+        task: task as OsmixWorkerPoolTask<T, unknown>,
+        eligibleWorkerIndexes,
+        priority: options.priority ?? 0,
+        timeoutMs: options.timeoutMs,
+        retry: options.retry ?? "never",
+        retryCount: 0,
+        signal: options.signal,
+        callerSettled: false,
+        resolve: (value) => resolve(value as R),
+        reject,
+      };
+      if (job.signal) {
+        job.abortListener = () => this.abortJob(job);
+        job.signal.addEventListener("abort", job.abortListener, { once: true });
+      }
+      this.queue.push(job);
+      this.schedulePump();
+    });
+  }
+
+  /** Queue one operation on a specific worker slot. */
+  runOn<R>(
+    workerIndex: number,
+    task: OsmixWorkerPoolTask<T, R>,
+    options: Omit<OsmixWorkerPoolRunOptions, "eligibleWorkerIndexes"> = {},
+  ): Promise<R> {
+    return this.run(task, { ...options, eligibleWorkerIndexes: [workerIndex] });
+  }
+
+  /** Run an operation once on every selected worker, returning results in index order. */
+  broadcast<R>(
+    task: OsmixWorkerPoolTask<T, R>,
+    options: OsmixWorkerPoolRunOptions = {},
+  ): Promise<R[]> {
+    const indexes = this.normalizeEligibleIndexes(options.eligibleWorkerIndexes);
+    const runOptions = { ...options };
+    delete runOptions.eligibleWorkerIndexes;
+    return Promise.all(indexes.map((index) => this.runOn(index, task, runOptions)));
+  }
+
+  /**
+   * Access a raw proxy without reserving its slot. Prefer `run()` for managed work.
+   * When omitted, the index advances round-robin across healthy workers.
+   */
+  getUnmanagedWorker(workerIndex?: number): Comlink.Remote<T> {
+    if (this.disposed) throw new OsmixWorkerPoolDisposedError();
+    if (workerIndex !== undefined) {
+      const slot = this.slots[workerIndex];
+      if (
+        !slot ||
+        slot.state === "failed" ||
+        slot.state === "disposed" ||
+        slot.state === "restarting"
+      ) {
+        throw new OsmixWorkerUnavailableError([workerIndex]);
+      }
+      return slot.connection.remote;
+    }
+    for (let offset = 0; offset < this.slots.length; offset++) {
+      const index = (this.unmanagedWorkerCursor + offset) % this.slots.length;
+      const slot = this.slots[index]!;
+      if (slot.state === "failed" || slot.state === "disposed" || slot.state === "restarting") {
+        continue;
+      }
+      this.unmanagedWorkerCursor = (index + 1) % this.slots.length;
+      return slot.connection.remote;
+    }
+    throw new OsmixWorkerUnavailableError(this.workerIndexes);
+  }
+
+  diagnostics(): OsmixWorkerPoolDiagnostics {
+    const workers = this.slots.map<OsmixWorkerPoolWorkerDiagnostics>((slot) => ({
+      index: slot.index,
+      runtime: slot.connection.runtime,
+      state: slot.state,
+      restartCount: slot.restartCount,
+    }));
+    return {
+      workerCount: workers.length,
+      queuedTaskCount: this.queue.length,
+      idleWorkerIndexes: workers
+        .filter((worker) => worker.state === "idle")
+        .map(({ index }) => index),
+      busyWorkerIndexes: workers
+        .filter((worker) => worker.state === "busy")
+        .map(({ index }) => index),
+      restartCount: workers.reduce((sum, worker) => sum + worker.restartCount, 0),
+      disposed: this.disposed,
+      workers,
+    };
+  }
+
+  private normalizeEligibleIndexes(indexes?: readonly number[]): readonly number[] {
+    const selected: number[] = indexes ? [...new Set(indexes)] : [...this.workerIndexes];
+    if (selected.length === 0) throw new Error("At least one eligible worker index is required");
+    for (const index of selected) {
+      if (!Number.isInteger(index) || index < 0 || index >= this.slots.length) {
+        throw new RangeError(`Worker index ${index} is outside the pool`);
+      }
+    }
+    return selected.sort((a, b) => a - b);
+  }
+
+  private abortJob(job: PoolJob<T>): void {
+    if (job.callerSettled) return;
+    job.callerSettled = true;
+    const queuedIndex = this.queue.indexOf(job);
+    if (queuedIndex !== -1) this.queue.splice(queuedIndex, 1);
+    this.removeAbortListener(job);
+    job.reject(job.signal ? abortReason(job.signal) : new DOMException("Aborted", "AbortError"));
+    this.schedulePump();
+  }
+
+  private removeAbortListener(job: PoolJob<T>): void {
+    if (job.signal && job.abortListener) {
+      job.signal.removeEventListener("abort", job.abortListener);
+      job.abortListener = undefined;
+    }
+  }
+
+  private schedulePump(): void {
+    if (this.disposed || this.pumpScheduled) return;
+    this.pumpScheduled = true;
+    queueMicrotask(() => {
+      this.pumpScheduled = false;
+      this.pump();
+    });
+  }
+
+  private pump(): void {
+    if (this.disposed) return;
+    const idleSlots = this.slots.filter((slot) => slot.state === "idle");
+    const jobs = [...this.queue].sort((a, b) => b.priority - a.priority || a.sequence - b.sequence);
+    const assignments = new Map<number, PoolJob<T>>();
+    const assign = (job: PoolJob<T>, visited: Set<number>): boolean => {
+      for (const slot of idleSlots) {
+        if (!job.eligibleWorkerIndexes.includes(slot.index) || visited.has(slot.index)) continue;
+        visited.add(slot.index);
+        const occupyingJob = assignments.get(slot.index);
+        if (occupyingJob && !assign(occupyingJob, visited)) continue;
+        assignments.set(slot.index, job);
+        return true;
+      }
+      return false;
+    };
+    for (const job of jobs) assign(job, new Set());
+
+    const scheduled = new Set(assignments.values());
+    for (let index = this.queue.length - 1; index >= 0; index--) {
+      if (scheduled.has(this.queue[index]!)) this.queue.splice(index, 1);
+    }
+    for (const slot of idleSlots) {
+      const job = assignments.get(slot.index);
+      if (job) void this.execute(slot, job);
+    }
+    this.rejectUnserviceableJobs();
+  }
+
+  private async execute(slot: WorkerSlot<T>, job: PoolJob<T>): Promise<void> {
+    if (job.callerSettled) {
+      this.schedulePump();
+      return;
+    }
+    slot.state = "busy";
+    slot.currentJob = job;
+    const generation = slot.generation;
+    const operation = Promise.resolve().then(() => job.task(slot.connection.remote, slot.index));
+    // A rejected operation after an abort/failure must never become unhandled.
+    operation.catch(() => undefined);
+    let result: unknown;
+    let error: unknown;
+    let rejected = false;
+    try {
+      const pending = Promise.race([operation, slot.failure.promise]);
+      result = job.timeoutMs
+        ? await withTimeout(
+            pending,
+            job.timeoutMs,
+            new OsmixWorkerTaskTimeoutError(slot.index, job.timeoutMs),
+          )
+        : await pending;
+    } catch (reason) {
+      error = reason;
+      rejected = true;
+    }
+
+    if (this.disposed || slot.generation !== generation) return;
+    slot.currentJob = undefined;
+    const workerFailed =
+      error instanceof OsmixWorkerConnectionError || error instanceof OsmixWorkerTaskTimeoutError;
+    if (workerFailed) {
+      if (!job.callerSettled && job.retry === "once" && job.retryCount === 0) {
+        job.retryCount++;
+        job.sequence = this.sequence++;
+        this.queue.push(job);
+      } else if (!job.callerSettled) {
+        job.callerSettled = true;
+        this.removeAbortListener(job);
+        job.reject(error);
+      }
+      void this.recoverSlot(slot);
+      this.schedulePump();
+      return;
+    }
+
+    slot.state = "idle";
+    if (!job.callerSettled) {
+      job.callerSettled = true;
+      this.removeAbortListener(job);
+      if (!rejected) job.resolve(result);
+      else job.reject(error);
+    }
+    this.schedulePump();
+  }
+
+  private recoverSlot(slot: WorkerSlot<T>): Promise<void> {
+    if (slot.recovery) return slot.recovery;
+    slot.recovery = this.performRecovery(slot).finally(() => {
+      slot.recovery = undefined;
+    });
+    return slot.recovery;
+  }
+
+  private async performRecovery(slot: WorkerSlot<T>): Promise<void> {
+    if (this.disposed || slot.state === "disposed") return;
+    slot.state = "restarting";
+    const generation = ++slot.generation;
+    slot.removeFailureListener();
+    await slot.connection.terminate().catch(() => undefined);
+    if (this.disposed || slot.generation !== generation) return;
+    if (slot.restartCount >= this.options.restartAttempts) {
+      slot.terminalError ??= slot.failureError;
+      slot.state = "failed";
+      this.rejectUnserviceableJobs();
+      return;
+    }
+    const restartCount = slot.restartCount + 1;
+    try {
+      const connection = await this.createConnection(slot.index);
+      if (this.disposed || slot.generation !== generation) {
+        await connection.terminate().catch(() => undefined);
+        return;
+      }
+      slot.connection = connection;
+      slot.restartCount = restartCount;
+      slot.failure = deferred<never>();
+      slot.failureError = undefined;
+      slot.terminalError = undefined;
+      slot.failure.promise.catch(() => undefined);
+      this.attachFailureListener(slot);
+      const ready = await withTimeout(
+        Promise.race([connection.remote.ping(), slot.failure.promise]),
+        this.options.probeTimeoutMs,
+        new OsmixWorkerTaskTimeoutError(slot.index, this.options.probeTimeoutMs),
+      );
+      if (this.disposed || slot.generation !== generation) return;
+      if (slot.failureError) throw slot.failureError;
+      if (ready !== true)
+        throw new Error(`Worker ${slot.index} returned an invalid probe response`);
+      if (this.options.restoreWorker) {
+        await withTimeout(
+          Promise.race([
+            this.options.restoreWorker(connection.remote, slot.index, restartCount),
+            slot.failure.promise,
+          ]),
+          this.options.restoreTimeoutMs,
+          new OsmixWorkerTaskTimeoutError(slot.index, this.options.restoreTimeoutMs),
+        );
+      }
+      if (this.disposed || slot.generation !== generation) return;
+      if (slot.failureError) throw slot.failureError;
+      slot.state = "idle";
+      this.schedulePump();
+    } catch (error) {
+      if (this.disposed || slot.generation !== generation) return;
+      slot.removeFailureListener();
+      await slot.connection.terminate().catch(() => undefined);
+      if (this.disposed || slot.generation !== generation) return;
+      slot.restartCount = restartCount;
+      slot.terminalError = error;
+      slot.state = "failed";
+      this.rejectUnserviceableJobs();
+    }
+  }
+
+  private rejectUnserviceableJobs(): void {
+    for (let index = this.queue.length - 1; index >= 0; index--) {
+      const job = this.queue[index]!;
+      const canRecover = job.eligibleWorkerIndexes.some((workerIndex) => {
+        const state = this.slots[workerIndex]?.state;
+        return state !== "failed" && state !== "disposed";
+      });
+      if (canRecover) continue;
+      this.queue.splice(index, 1);
+      if (!job.callerSettled) {
+        job.callerSettled = true;
+        this.removeAbortListener(job);
+        const terminalError = job.eligibleWorkerIndexes
+          .map((workerIndex) => this.slots[workerIndex]?.terminalError)
+          .find((error) => error !== undefined);
+        job.reject(terminalError ?? new OsmixWorkerUnavailableError(job.eligibleWorkerIndexes));
+      }
+    }
+  }
+
+  /** Dispose queued work and terminate every worker. Safe to call repeatedly. */
+  dispose(): Promise<void> {
+    if (this.disposePromise) return this.disposePromise;
+    this.disposed = true;
+    const error = new OsmixWorkerPoolDisposedError();
+    const recoveries = this.slots.flatMap((slot) => (slot.recovery ? [slot.recovery] : []));
+    for (const job of this.queue.splice(0)) {
+      if (!job.callerSettled) {
+        job.callerSettled = true;
+        this.removeAbortListener(job);
+        job.reject(error);
+      }
+    }
+    for (const slot of this.slots) {
+      const job = slot.currentJob;
+      if (job && !job.callerSettled) {
+        job.callerSettled = true;
+        this.removeAbortListener(job);
+        job.reject(error);
+      }
+      slot.currentJob = undefined;
+      slot.state = "disposed";
+      slot.generation++;
+      slot.removeFailureListener();
+      slot.failure.reject(error);
+    }
+    this.disposePromise = Promise.all([
+      ...this.slots.map((slot) => slot.connection.terminate().catch(() => undefined)),
+      ...recoveries,
+    ]).then(() => undefined);
+    return this.disposePromise;
+  }
+
+  [Symbol.dispose](): void {
+    void this.dispose();
+  }
+
+  async [Symbol.asyncDispose](): Promise<void> {
+    await this.dispose();
+  }
+}
+
+/** Create and probe every slot in an `OsmixWorkerPool`. */
+export function createOsmixWorkerPool<T extends OsmixWorkerPingTarget = OsmixWorker>(
+  options: OsmixWorkerPoolOptions<T> = {},
+): Promise<OsmixWorkerPool<T>> {
+  return OsmixWorkerPool.create(options);
+}
+
+export {
+  createOsmixWorkerConnection,
+  defaultOsmixWorkerUrl,
+  exposeOsmixWorker,
+  type CreateOsmixWorkerConnectionOptions,
+  type OsmixWorkerConnection,
+  type WorkerConnectionRuntime,
+} from "./worker-runtime.ts";

--- a/packages/osmix/src/worker-runtime.ts
+++ b/packages/osmix/src/worker-runtime.ts
@@ -1,0 +1,273 @@
+/** Cross-runtime worker creation and Comlink endpoint helpers. */
+
+import * as Comlink from "comlink";
+import type { Endpoint } from "comlink";
+
+import { getWorkerRuntime, type WorkerRuntime } from "./capabilities.ts";
+import { OsmixWorker } from "./worker.ts";
+
+const NODE_WORKER_THREADS_SPECIFIER = "node:worker_threads";
+
+async function importNodeWorkerThreads(): Promise<typeof import("node:worker_threads")> {
+  // Keep the Node builtin out of browser bundles. This branch is reached only
+  // after runtime detection selects Node.
+  return import(/* @vite-ignore */ NODE_WORKER_THREADS_SPECIFIER);
+}
+
+interface NodeEndpointTarget {
+  postMessage(message: unknown, transfer?: readonly Transferable[]): void;
+  on(type: "message", listener: (data: unknown) => void): unknown;
+  off(type: "message", listener: (data: unknown) => void): unknown;
+  start?(): void;
+}
+
+interface ManagedWebEndpoint extends Endpoint {
+  clear(): void;
+}
+
+/** Track Comlink's anonymous message listener so server runtimes can release their event loop. */
+function webEndpoint(target: Worker): ManagedWebEndpoint {
+  const listeners = new Map<
+    EventListenerOrEventListenerObject,
+    EventListenerOrEventListenerObject
+  >();
+  return {
+    postMessage: (message, transfer) =>
+      target.postMessage(message, transfer ? { transfer } : undefined),
+    addEventListener: (type, listener) => {
+      target.addEventListener(type, listener);
+      listeners.set(listener, listener);
+    },
+    removeEventListener: (type, listener) => {
+      const registered = listeners.get(listener);
+      if (!registered) return;
+      target.removeEventListener(type, registered);
+      listeners.delete(listener);
+    },
+    clear() {
+      for (const listener of listeners.values()) target.removeEventListener("message", listener);
+      listeners.clear();
+    },
+  };
+}
+
+/** Comlink's Node adapter, kept local so browser consumers do not resolve a Node-only subpath. */
+function nodeEndpoint(target: NodeEndpointTarget): Endpoint {
+  const listeners = new WeakMap<EventListenerOrEventListenerObject, (data: unknown) => void>();
+  return {
+    postMessage: (message, transfer) => target.postMessage(message, transfer),
+    addEventListener: (_type, listener) => {
+      const wrapped = (data: unknown) => {
+        const event = { data } as MessageEvent;
+        if ("handleEvent" in listener) listener.handleEvent(event);
+        else listener(event);
+      };
+      target.on("message", wrapped);
+      listeners.set(listener, wrapped);
+    },
+    removeEventListener: (_type, listener) => {
+      const wrapped = listeners.get(listener);
+      if (!wrapped) return;
+      target.off("message", wrapped);
+      listeners.delete(listener);
+    },
+    start: target.start ? () => target.start?.() : undefined,
+  };
+}
+
+export type WorkerConnectionRuntime = Exclude<WorkerRuntime, "none"> | "in-process";
+type WebWorkerRuntime = Exclude<WorkerRuntime, "node" | "none">;
+
+/** A remote proxy paired with the underlying worker lifecycle. */
+export interface OsmixWorkerConnection<T extends object> {
+  readonly remote: Comlink.Remote<T>;
+  readonly runtime: WorkerConnectionRuntime;
+  onFailure(listener: (error: Error) => void): () => void;
+  terminate(): Promise<void>;
+}
+
+/** Options for creating one browser, Bun, Deno, Node, or in-process worker connection. */
+export interface CreateOsmixWorkerConnectionOptions<T extends object> {
+  workerUrl?: URL;
+  runtime?: WorkerRuntime | "auto";
+  inProcessWorker?: T;
+}
+
+/** Resolve the default worker entry beside the current source or built module. */
+export function defaultOsmixWorkerUrl(moduleUrl: string | URL = import.meta.url): URL {
+  const base = new URL(moduleUrl);
+  const ext = base.pathname.endsWith(".ts") ? "ts" : "js";
+  return new URL(`./osmix.worker.${ext}`, base);
+}
+
+function errorFrom(value: unknown, fallback: string): Error {
+  if (value instanceof Error) return value;
+  if (
+    typeof value === "object" &&
+    value &&
+    "message" in value &&
+    typeof value.message === "string" &&
+    value.message.length > 0
+  ) {
+    return new Error(value.message);
+  }
+  return new Error(fallback);
+}
+
+function createInProcessConnection<T extends object>(worker: T): OsmixWorkerConnection<T> {
+  // In-process mode is explicitly blocking, so an RPC bridge only adds lifecycle
+  // races without providing isolation. Awaiting direct method results remains
+  // compatible with the Comlink.Remote surface used by callers.
+  const remote = worker as unknown as Comlink.Remote<T>;
+  let terminated = false;
+  return {
+    remote,
+    runtime: "in-process",
+    onFailure: () => () => undefined,
+    async terminate() {
+      if (terminated) return;
+      terminated = true;
+    },
+  };
+}
+
+async function createWebConnection<T extends object>(
+  workerUrl: URL,
+  runtime: WebWorkerRuntime,
+): Promise<OsmixWorkerConnection<T>> {
+  if (typeof Worker === "undefined") {
+    throw new Error(`The ${runtime} Web Worker API is not available in this context`);
+  }
+  const worker = new Worker(workerUrl, { type: "module" });
+  const endpoint = webEndpoint(worker);
+  const remote = Comlink.wrap<T>(endpoint);
+  const listeners = new Set<(error: Error) => void>();
+  let terminated = false;
+  let terminalFailure: Error | undefined;
+  const notify = (error: Error) => {
+    if (terminated || terminalFailure) return;
+    terminalFailure = error;
+    for (const listener of listeners) listener(error);
+  };
+  const onError = (event: ErrorEvent) => {
+    const error = errorFrom(event.error ?? event, `Worker failed to start: ${workerUrl.href}`);
+    notify(error);
+  };
+  const onMessageError = (event: MessageEvent) => {
+    const error = errorFrom(event.data, "Worker message could not be deserialized");
+    notify(error);
+  };
+  const onClose: EventListener = (event) => {
+    const code = Reflect.get(event, "code");
+    notify(new Error(`Bun Worker exited unexpectedly with code ${String(code ?? "unknown")}`));
+  };
+  worker.addEventListener("error", onError);
+  worker.addEventListener("messageerror", onMessageError);
+  if (runtime === "bun") worker.addEventListener("close", onClose);
+  return {
+    remote,
+    runtime,
+    onFailure(listener) {
+      listeners.add(listener);
+      if (terminalFailure) queueMicrotask(() => listener(terminalFailure!));
+      return () => listeners.delete(listener);
+    },
+    async terminate() {
+      if (terminated) return;
+      terminated = true;
+      worker.removeEventListener("error", onError);
+      worker.removeEventListener("messageerror", onMessageError);
+      if (runtime === "bun") worker.removeEventListener("close", onClose);
+      listeners.clear();
+      try {
+        remote[Comlink.releaseProxy]();
+      } catch {
+        // A failed endpoint may already have released its proxy.
+      } finally {
+        endpoint.clear();
+        worker.terminate();
+      }
+    },
+  };
+}
+
+async function createNodeConnection<T extends object>(
+  workerUrl: URL,
+): Promise<OsmixWorkerConnection<T>> {
+  const { Worker: NodeWorker } = await importNodeWorkerThreads();
+  const worker = new NodeWorker(workerUrl);
+  const remote = Comlink.wrap<T>(nodeEndpoint(worker as unknown as NodeEndpointTarget));
+  const listeners = new Set<(error: Error) => void>();
+  let terminated = false;
+  let terminalFailure: Error | undefined;
+  const notify = (error: Error) => {
+    if (terminated || terminalFailure) return;
+    terminalFailure = error;
+    for (const listener of listeners) listener(error);
+  };
+  const onError = (error: Error) => notify(error);
+  const onMessageError = (error: Error) =>
+    notify(errorFrom(error, "Worker message could not be deserialized"));
+  const onExit = (code: number) => {
+    if (!terminated) notify(new Error(`Worker exited unexpectedly with code ${code}`));
+  };
+  worker.on("error", onError);
+  worker.on("messageerror", onMessageError);
+  worker.on("exit", onExit);
+  return {
+    remote,
+    runtime: "node",
+    onFailure(listener) {
+      listeners.add(listener);
+      if (terminalFailure) queueMicrotask(() => listener(terminalFailure!));
+      return () => listeners.delete(listener);
+    },
+    async terminate() {
+      if (terminated) return;
+      terminated = true;
+      worker.off("error", onError);
+      worker.off("messageerror", onMessageError);
+      worker.off("exit", onExit);
+      listeners.clear();
+      try {
+        remote[Comlink.releaseProxy]();
+      } catch {
+        // A failed endpoint may already have released its proxy.
+      } finally {
+        await worker.terminate();
+      }
+    },
+  };
+}
+
+/** Create a Comlink worker connection in browsers, Bun, Deno, Node, or in-process. */
+export async function createOsmixWorkerConnection<T extends object = OsmixWorker>({
+  workerUrl = defaultOsmixWorkerUrl(),
+  runtime = "auto",
+  inProcessWorker,
+}: CreateOsmixWorkerConnectionOptions<T> = {}): Promise<OsmixWorkerConnection<T>> {
+  if (inProcessWorker) return createInProcessConnection(inProcessWorker);
+  const selected = runtime === "auto" ? getWorkerRuntime() : runtime;
+  if (selected === "web" || selected === "bun" || selected === "deno") {
+    return createWebConnection<T>(workerUrl, selected);
+  }
+  if (selected === "node") return createNodeConnection<T>(workerUrl);
+  throw new Error(
+    "Worker threads are not available in this runtime. Pass an inProcessWorker to run locally.",
+  );
+}
+
+/** Expose an Osmix worker through a browser/Bun/Deno global or Node parent-port endpoint. */
+export async function exposeOsmixWorker<T extends object>(worker: T): Promise<void> {
+  const runtime = getWorkerRuntime();
+  if (runtime === "node") {
+    const { parentPort } = await importNodeWorkerThreads();
+    if (!parentPort) throw new Error("exposeOsmixWorker must run inside a Node worker thread");
+    Comlink.expose(worker, nodeEndpoint(parentPort as unknown as NodeEndpointTarget));
+    return;
+  }
+  if (runtime === "none") {
+    throw new Error("exposeOsmixWorker must run inside a supported worker context");
+  }
+  Comlink.expose(worker);
+}

--- a/packages/osmix/src/worker.ts
+++ b/packages/osmix/src/worker.ts
@@ -1,7 +1,7 @@
 /**
- * Web Worker implementation for OSM operations.
+ * Worker implementation for OSM operations.
  *
- * OsmixWorker runs inside a Web Worker and manages multiple Osm instances.
+ * OsmixWorker runs inside a browser Worker or Node worker thread and manages multiple Osm instances.
  * It exposes methods via Comlink for cross-thread RPC from OsmixRemote.
  *
  * Can be extended to add custom functionality:
@@ -64,7 +64,7 @@ import { type DrawToRasterTileOptions, drawToRasterTile } from "./raster.ts";
 import { transfer } from "./utils.ts";
 
 /**
- * Worker handler for managing multiple Osm instances within a Web Worker.
+ * Worker handler for managing multiple Osm instances off the calling thread.
  * Exposes Comlink-wrapped methods for off-thread Osm data operations.
  */
 export class OsmixWorker extends EventTarget {
@@ -77,6 +77,11 @@ export class OsmixWorker extends EventTarget {
   private filteredChanges = new Map<string, OsmChange[]>();
 
   private onProgress = (progress: ProgressEvent) => this.dispatchEvent(progress);
+
+  /** Confirm that the worker RPC endpoint is ready to receive operations. */
+  ping(): true {
+    return true;
+  }
 
   /**
    * Register a progress listener to receive updates during long-running operations.

--- a/packages/osmix/test/capabilities.test.ts
+++ b/packages/osmix/test/capabilities.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { canShareArrayBuffers, getOsmixCapabilities } from "../src/capabilities";
+import {
+  canShareArrayBuffers,
+  getOsmixCapabilities,
+  getWorkerRuntime,
+  selectWorkerCount,
+} from "../src/capabilities";
 
 describe("capabilities", () => {
   afterEach(() => {
@@ -15,16 +20,18 @@ describe("capabilities", () => {
 
     it("is false with SharedArrayBuffer but no cross-origin isolation", () => {
       // The browser trap: the constructor exists but SABs cannot be posted.
+      vi.stubGlobal("process", undefined);
       vi.stubGlobal("crossOriginIsolated", false);
       expect(canShareArrayBuffers()).toBe(false);
     });
 
     it("is true in a cross-origin isolated context", () => {
+      vi.stubGlobal("process", undefined);
       vi.stubGlobal("crossOriginIsolated", true);
       expect(canShareArrayBuffers()).toBe(true);
     });
 
-    it("is true in runtimes without crossOriginIsolated (Node)", () => {
+    it("is true in server runtimes without crossOriginIsolated", () => {
       expect("crossOriginIsolated" in globalThis).toBe(false);
       expect(canShareArrayBuffers()).toBe(true);
     });
@@ -35,20 +42,24 @@ describe("capabilities", () => {
       vi.stubGlobal("navigator", undefined);
       const capabilities = getOsmixCapabilities();
       expect(capabilities.hardwareConcurrency).toBe(1);
+      expect(capabilities.workerRuntime).toBe("node");
     });
 
     it("limits maxWorkers to 1 without SharedArrayBuffer sharing", () => {
+      vi.stubGlobal("process", undefined);
       vi.stubGlobal("Worker", class {});
       vi.stubGlobal("crossOriginIsolated", false);
       vi.stubGlobal("navigator", { hardwareConcurrency: 8 });
       const capabilities = getOsmixCapabilities();
       expect(capabilities.webWorkers).toBe(true);
+      expect(capabilities.workerRuntime).toBe("web");
       expect(capabilities.canShareArrayBuffers).toBe(false);
       expect(capabilities.maxWorkers).toBe(1);
       expect(capabilities.recommendedMode).toBe("single-worker");
     });
 
     it("recommends multi-worker in a cross-origin isolated context", () => {
+      vi.stubGlobal("process", undefined);
       vi.stubGlobal("Worker", class {});
       vi.stubGlobal("crossOriginIsolated", true);
       vi.stubGlobal("navigator", { hardwareConcurrency: 8 });
@@ -57,11 +68,55 @@ describe("capabilities", () => {
       expect(capabilities.recommendedMode).toBe("multi-worker");
     });
 
-    it("recommends in-process mode without Web Workers", () => {
+    it("recommends Node worker threads without a Web Worker global", () => {
       const capabilities = getOsmixCapabilities();
       expect(capabilities.webWorkers).toBe(false);
-      expect(capabilities.maxWorkers).toBe(1);
-      expect(capabilities.recommendedMode).toBe("in-process");
+      expect(capabilities.workerRuntime).toBe("node");
+      expect(capabilities.maxWorkers).toBe(capabilities.hardwareConcurrency);
+      expect(capabilities.recommendedMode).toBe(
+        capabilities.hardwareConcurrency > 1 ? "multi-worker" : "single-worker",
+      );
+    });
+
+    it("recommends in-process mode when neither worker implementation exists", () => {
+      vi.stubGlobal("process", undefined);
+      vi.stubGlobal("Worker", undefined);
+      expect(getWorkerRuntime()).toBe("none");
+      expect(getOsmixCapabilities().recommendedMode).toBe("in-process");
+    });
+
+    it("detects a browser worker runtime independently of Node", () => {
+      vi.stubGlobal("process", undefined);
+      vi.stubGlobal("Worker", class {});
+      expect(getWorkerRuntime()).toBe("web");
+      expect(getOsmixCapabilities().workerRuntime).toBe("web");
+    });
+
+    it("detects Bun before its Node compatibility globals", () => {
+      vi.stubGlobal("Bun", { version: "1.3.14" });
+      vi.stubGlobal("Worker", class {});
+      expect(getWorkerRuntime()).toBe("bun");
+      expect(getOsmixCapabilities().workerRuntime).toBe("bun");
+      expect(getOsmixCapabilities().recommendedMode).not.toBe("in-process");
+    });
+
+    it("detects Deno before optional Node compatibility globals", () => {
+      vi.stubGlobal("Deno", { version: { deno: "2.7.0" } });
+      vi.stubGlobal("Worker", class {});
+      expect(getWorkerRuntime()).toBe("deno");
+      expect(getOsmixCapabilities().workerRuntime).toBe("deno");
+      expect(getOsmixCapabilities().recommendedMode).not.toBe("in-process");
+    });
+  });
+
+  describe("selectWorkerCount", () => {
+    it("reserves cores, applies a cap, and always returns at least one", () => {
+      expect(selectWorkerCount({ hardwareConcurrency: 8, reserveCores: 1, maxWorkers: 4 })).toBe(4);
+      expect(selectWorkerCount({ hardwareConcurrency: 3, reserveCores: 1, maxWorkers: 4 })).toBe(2);
+      expect(selectWorkerCount({ hardwareConcurrency: 1, reserveCores: 1, maxWorkers: 4 })).toBe(1);
+      expect(selectWorkerCount({ hardwareConcurrency: 8, reserveCores: 20, maxWorkers: 0 })).toBe(
+        1,
+      );
     });
   });
 });

--- a/packages/osmix/test/fixtures/pool.worker.mjs
+++ b/packages/osmix/test/fixtures/pool.worker.mjs
@@ -1,0 +1,46 @@
+import { threadId, parentPort } from "node:worker_threads";
+
+import * as Comlink from "comlink";
+import nodeEndpoint from "comlink/dist/esm/node-adapter.mjs";
+
+if (!parentPort) throw new Error("Expected a worker-thread parent port");
+
+class PoolTestWorker {
+  sharedBytes = null;
+
+  ping() {
+    return true;
+  }
+
+  getThreadId() {
+    return threadId;
+  }
+
+  block(milliseconds) {
+    const end = performance.now() + milliseconds;
+    while (performance.now() < end) {
+      // Deliberately keep this worker busy to verify the caller remains responsive.
+    }
+    return threadId;
+  }
+
+  crash() {
+    process.exit(1);
+  }
+
+  installSharedBuffer(buffer) {
+    this.sharedBytes = new Uint8Array(buffer);
+    return buffer instanceof SharedArrayBuffer;
+  }
+
+  readSharedByte(index) {
+    return this.sharedBytes?.[index];
+  }
+
+  writeSharedByte(index, value) {
+    if (!this.sharedBytes) throw new Error("Shared buffer is not installed");
+    this.sharedBytes[index] = value;
+  }
+}
+
+Comlink.expose(new PoolTestWorker(), nodeEndpoint(parentPort));

--- a/packages/osmix/test/merge.test.ts
+++ b/packages/osmix/test/merge.test.ts
@@ -122,7 +122,7 @@ describe("merge osm", () => {
         },
       });
     },
-    10_000,
+    30_000,
   );
 
   it.skip("should merge seattle with deduplication", async () => {

--- a/packages/osmix/test/remote.test.ts
+++ b/packages/osmix/test/remote.test.ts
@@ -3,12 +3,36 @@ import { getFixtureFile, getFixtureFileReadStream, PBFs } from "@osmix/test-util
 import type { FeatureCollection, LineString, Point } from "geojson";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
-import { createRemote } from "../src/remote";
+import { createRemote, OsmixDatasetLossError, OsmixRemote } from "../src/remote";
 
 const monacoPbf = PBFs["monaco"]!;
 const occupiedMonacoTile: [number, number, number] = [17059, 11948, 15];
 // Increase timeout for worker tests
 const workerTestTimeout = 30_000;
+
+class RecoveryTestRemote extends OsmixRemote {
+  private readonly customSources = new Map<string, Uint8Array>();
+
+  async restoreForTest(): Promise<void> {
+    await this.restorePoolWorker(this.getWorker(), 0, 1);
+  }
+
+  registerCustomGeoJson(id: string, data: Uint8Array): void {
+    this.customSources.set(id, data);
+    this.registerDatasetForRecovery(id);
+  }
+
+  registerMissing(id: string): void {
+    this.registerDatasetForRecovery(id);
+  }
+
+  protected override async recoverDataset(worker: ReturnType<this["getWorker"]>, id: string) {
+    const source = this.customSources.get(id);
+    if (!source) return false;
+    await worker.fromGeoJSON({ data: source.slice().buffer, options: { id } });
+    return true;
+  }
+}
 
 describe("OsmixRemote", () => {
   afterEach(async () => {
@@ -178,6 +202,104 @@ describe("OsmixRemote", () => {
       },
       workerTestTimeout,
     );
+  });
+
+  describe("restart dataset recovery", () => {
+    const geojson: FeatureCollection<Point> = {
+      type: "FeatureCollection",
+      features: [
+        {
+          type: "Feature",
+          geometry: { type: "Point", coordinates: [7.42, 43.73] },
+          properties: { name: "Replay me" },
+        },
+      ],
+    };
+
+    it("replays a File source without retaining a separate input buffer", async () => {
+      using remote = new RecoveryTestRemote();
+      await remote.initializeWorkerPool(1, undefined, undefined, true);
+      const file = new File([JSON.stringify(geojson)], "replay.geojson", {
+        type: "application/geo+json",
+      });
+      const dataset = await remote.fromGeoJSON(file, { id: "file-recovery" });
+      await remote.getWorker().delete(dataset.id);
+
+      await remote.restoreForTest();
+
+      await expect(remote.has(dataset.id)).resolves.toBe(true);
+    });
+
+    it("uses subclass-owned durable recovery sources", async () => {
+      using remote = new RecoveryTestRemote();
+      await remote.initializeWorkerPool(1, undefined, undefined, true);
+      const data = new TextEncoder().encode(JSON.stringify(geojson));
+      const dataset = await remote.fromGeoJSON(data.slice(), { id: "custom-recovery" });
+      remote.registerCustomGeoJson(dataset.id, data);
+      await remote.getWorker().delete(dataset.id);
+
+      await remote.restoreForTest();
+
+      await expect(remote.has(dataset.id)).resolves.toBe(true);
+    });
+
+    it("throws a typed error instead of exposing an empty restarted worker", async () => {
+      using remote = new RecoveryTestRemote();
+      await remote.initializeWorkerPool(1, undefined, undefined, true);
+      remote.registerMissing("one-shot-source");
+
+      await expect(remote.restoreForTest()).rejects.toMatchObject({
+        name: "OsmixDatasetLossError",
+        datasetIds: ["one-shot-source"],
+        workerIndex: 0,
+      } satisfies Partial<OsmixDatasetLossError>);
+    });
+
+    it("reattaches the progress listener before a restored slot becomes available", async () => {
+      using remote = new RecoveryTestRemote();
+      await remote.initializeWorkerPool(1, undefined, vi.fn(), true);
+      const worker = remote.getWorker();
+      const addProgressListener = vi.spyOn(worker, "addProgressListener");
+
+      await remote.restoreForTest();
+
+      expect(addProgressListener).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("partial state broadcasts", () => {
+    it("makes the remote terminal when a mutation fails after committing", async () => {
+      using remote = new RecoveryTestRemote();
+      await remote.initializeWorkerPool(1, undefined, undefined, true);
+      const data = new TextEncoder().encode(
+        JSON.stringify({
+          type: "FeatureCollection",
+          features: [],
+        }),
+      );
+      const dataset = await remote.fromGeoJSON(data, { id: "partial-delete" });
+      const worker = remote.getWorker() as unknown as {
+        delete(id: string): void;
+      };
+      const deleteDataset = worker.delete.bind(worker);
+      worker.delete = (id) => {
+        deleteDataset(id);
+        throw new Error("failed after delete");
+      };
+
+      await expect(remote.delete(dataset.id)).rejects.toMatchObject({
+        name: "OsmixRemoteStateError",
+        operation: "dataset deletion",
+      });
+      await expect(remote.has(dataset.id)).rejects.toMatchObject({
+        name: "OsmixRemoteStateError",
+        operation: "dataset deletion",
+      });
+      await expect(remote.isReady(dataset.id)).rejects.toMatchObject({
+        name: "OsmixRemoteStateError",
+        operation: "dataset deletion",
+      });
+    });
   });
 
   describe("get", () => {
@@ -438,13 +560,15 @@ describe("OsmixRemote", () => {
       workerTestTimeout,
     );
 
-    it("should throw without Web Worker support when inProcess is not set", async () => {
-      // Node has no global Worker, so spawning real workers must fail loudly.
-      await expect(createRemote()).rejects.toThrow(/Web Workers are not available/);
-      await expect(createRemote({ workerCount: 3 })).rejects.toThrow(
-        /Web Workers are not available/,
-      );
-    });
+    it(
+      "uses Node worker threads when Web Workers are unavailable",
+      async () => {
+        using remote = await createRemote({ workerCount: 1 });
+        expect(remote.mode).toBe("single-worker");
+        await expect(remote.runWithWorker((worker) => worker.ping())).resolves.toBe(true);
+      },
+      workerTestTimeout,
+    );
 
     it("should reject invalid worker pool configurations", async () => {
       await expect(createRemote({ workerCount: 0 })).rejects.toThrow(/at least 1/);
@@ -459,57 +583,6 @@ describe("OsmixRemote", () => {
       ).rejects.toThrow(/cannot be used in in-process mode/);
     });
 
-    it("terminates raw workers exactly once when disposed", async () => {
-      class MockWorker {
-        static instances: MockWorker[] = [];
-
-        readonly terminate = vi.fn();
-
-        constructor() {
-          MockWorker.instances.push(this);
-        }
-
-        addEventListener() {}
-
-        postMessage() {}
-      }
-
-      vi.stubGlobal("Worker", MockWorker);
-      const remote = await createRemote({ workerCount: 1 });
-
-      remote.terminate();
-      remote[Symbol.dispose]();
-
-      expect(MockWorker.instances).toHaveLength(1);
-      expect(MockWorker.instances[0]?.terminate).toHaveBeenCalledTimes(1);
-      expect(remote.workerCount).toBe(0);
-      expect(() => remote.mode).toThrow(/not initialized/);
-    });
-
-    it("cleans up workers created before initialization fails", async () => {
-      class MockWorker {
-        static instances: MockWorker[] = [];
-
-        readonly terminate = vi.fn();
-
-        constructor() {
-          if (MockWorker.instances.length === 1) throw Error("second worker failed");
-          MockWorker.instances.push(this);
-        }
-
-        addEventListener() {}
-
-        postMessage() {}
-      }
-
-      vi.stubGlobal("Worker", MockWorker);
-
-      await expect(createRemote({ workerCount: 2 })).rejects.toThrow("second worker failed");
-
-      expect(MockWorker.instances).toHaveLength(1);
-      expect(MockWorker.instances[0]?.terminate).toHaveBeenCalledTimes(1);
-    });
-
     it("makes in-process disposal idempotent", async () => {
       const remote = await createRemote({ inProcess: true });
 
@@ -520,6 +593,7 @@ describe("OsmixRemote", () => {
       }).not.toThrow();
       expect(remote.workerCount).toBe(0);
       expect(() => remote.getWorker()).toThrow(/No worker available/);
+      await Promise.all([remote.dispose(), remote.dispose(), remote[Symbol.asyncDispose]()]);
     });
   });
 });

--- a/packages/osmix/test/utils.test.ts
+++ b/packages/osmix/test/utils.test.ts
@@ -1,6 +1,8 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { collectTransferables } from "../src/utils";
+import { collectTransferables, supportsReadableStreamTransfer } from "../src/utils";
+
+afterEach(() => vi.unstubAllGlobals());
 
 describe("collectTransferables", () => {
   it("collects each ArrayBuffer only once across nested aliases", () => {
@@ -24,5 +26,28 @@ describe("collectTransferables", () => {
     const view = new Uint8Array(buffer);
 
     expect(collectTransferables({ buffer, view })).toEqual([]);
+  });
+});
+
+describe("supportsReadableStreamTransfer", () => {
+  it.each([false, true])("closes both probe ports when posting throws: %s", (shouldThrow) => {
+    const port1 = {
+      close: vi.fn(),
+      postMessage: vi.fn(() => {
+        if (shouldThrow) throw new DOMException("unsupported", "DataCloneError");
+      }),
+    };
+    const port2 = { close: vi.fn() };
+    vi.stubGlobal(
+      "MessageChannel",
+      class {
+        readonly port1 = port1;
+        readonly port2 = port2;
+      },
+    );
+
+    expect(supportsReadableStreamTransfer()).toBe(!shouldThrow);
+    expect(port1.close).toHaveBeenCalledOnce();
+    expect(port2.close).toHaveBeenCalledOnce();
   });
 });

--- a/packages/osmix/test/worker-pool.test.ts
+++ b/packages/osmix/test/worker-pool.test.ts
@@ -1,0 +1,586 @@
+import { threadId } from "node:worker_threads";
+
+import * as Comlink from "comlink";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  createOsmixWorkerConnection,
+  createOsmixWorkerPool,
+  defaultOsmixWorkerUrl,
+  type OsmixWorkerConnection,
+  OsmixWorkerPoolDisposedError,
+  OsmixWorkerTaskTimeoutError,
+  type OsmixWorkerPingTarget,
+} from "../src/worker-pool.ts";
+import { OsmixWorker } from "../src/worker.ts";
+
+interface TestWorker extends OsmixWorkerPingTarget {
+  value: number;
+}
+
+interface NodeTestWorker extends OsmixWorkerPingTarget {
+  block(milliseconds: number): number;
+  crash(): never;
+  getThreadId(): number;
+  installSharedBuffer(buffer: SharedArrayBuffer): boolean;
+  readSharedByte(index: number): number | undefined;
+  writeSharedByte(index: number, value: number): void;
+}
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve(value: T): void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+class FakeConnection implements OsmixWorkerConnection<TestWorker> {
+  readonly runtime = "in-process" as const;
+  readonly remote: Comlink.Remote<TestWorker>;
+  readonly terminate = vi.fn(async () => undefined);
+  private readonly failureListeners = new Set<(error: Error) => void>();
+
+  constructor(value: number, ping: () => Promise<true> = async () => true) {
+    this.remote = {
+      ping: vi.fn(ping),
+      value: Promise.resolve(value),
+      [Comlink.createEndpoint]: vi.fn(),
+      [Comlink.releaseProxy]: vi.fn(),
+    } as unknown as Comlink.Remote<TestWorker>;
+  }
+
+  onFailure(listener: (error: Error) => void): () => void {
+    this.failureListeners.add(listener);
+    return () => this.failureListeners.delete(listener);
+  }
+
+  fail(error = new Error("worker crashed")): void {
+    for (const listener of this.failureListeners) listener(error);
+  }
+}
+
+class FakeWebWorker {
+  static latest: FakeWebWorker | undefined;
+  readonly terminate = vi.fn();
+  private readonly listeners = new Map<string, Set<EventListenerOrEventListenerObject>>();
+
+  constructor() {
+    FakeWebWorker.latest = this;
+  }
+
+  postMessage(): void {}
+
+  addEventListener(type: string, listener: EventListenerOrEventListenerObject): void {
+    const listeners = this.listeners.get(type) ?? new Set();
+    listeners.add(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  removeEventListener(type: string, listener: EventListenerOrEventListenerObject): void {
+    this.listeners.get(type)?.delete(listener);
+  }
+
+  dispatch(type: string, event: Event): void {
+    for (const listener of this.listeners.get(type) ?? []) {
+      if ("handleEvent" in listener) listener.handleEvent(event);
+      else listener(event);
+    }
+  }
+}
+
+describe("OsmixWorkerPool", () => {
+  it.each(["error", "messageerror"] as const)(
+    "reports browser Worker %s events as connection failures",
+    async (type) => {
+      vi.stubGlobal("Worker", FakeWebWorker);
+      const connection = await createOsmixWorkerConnection<TestWorker>({
+        runtime: "web",
+        workerUrl: new URL("https://example.com/test.worker.js"),
+      });
+      const onFailure = vi.fn();
+      connection.onFailure(onFailure);
+      const failure = new Error(`${type} failure`);
+      const event =
+        type === "error" ? ({ error: failure } as ErrorEvent) : ({ data: failure } as MessageEvent);
+
+      FakeWebWorker.latest!.dispatch(type, event as Event);
+
+      await vi.waitFor(() => expect(onFailure).toHaveBeenCalledWith(failure));
+      await connection.terminate();
+      expect(FakeWebWorker.latest!.terminate).toHaveBeenCalledOnce();
+      vi.unstubAllGlobals();
+    },
+  );
+
+  it.each(["web", "bun", "deno"] as const)(
+    "uses the Web Worker transport for the %s runtime",
+    async (runtime) => {
+      vi.stubGlobal("Worker", FakeWebWorker);
+      const connection = await createOsmixWorkerConnection<TestWorker>({
+        runtime,
+        workerUrl: new URL("https://example.com/test.worker.js"),
+      });
+
+      expect(connection.runtime).toBe(runtime);
+      await connection.terminate();
+      expect(FakeWebWorker.latest!.terminate).toHaveBeenCalledOnce();
+      vi.unstubAllGlobals();
+    },
+  );
+
+  it("reports Bun Worker close events as connection failures", async () => {
+    vi.stubGlobal("Worker", FakeWebWorker);
+    const connection = await createOsmixWorkerConnection<TestWorker>({
+      runtime: "bun",
+      workerUrl: new URL("file:///test.worker.js"),
+    });
+    const onFailure = vi.fn();
+    connection.onFailure(onFailure);
+
+    FakeWebWorker.latest!.dispatch("close", { code: 7 } as CloseEvent);
+
+    await vi.waitFor(() =>
+      expect(onFailure).toHaveBeenCalledWith(
+        expect.objectContaining({ message: "Bun Worker exited unexpectedly with code 7" }),
+      ),
+    );
+    await connection.terminate();
+    vi.unstubAllGlobals();
+  });
+
+  it("resolves source and built worker siblings when module URLs have cache suffixes", () => {
+    expect(
+      defaultOsmixWorkerUrl("https://example.com/osmix/worker-runtime.ts?t=123#dev").href,
+    ).toBe("https://example.com/osmix/osmix.worker.ts");
+    expect(defaultOsmixWorkerUrl("https://example.com/osmix/worker-runtime.js?v=1").href).toBe(
+      "https://example.com/osmix/osmix.worker.js",
+    );
+  });
+
+  it("terminates earlier slots when a later startup probe fails", async () => {
+    const first = new FakeConnection(0);
+    const failed = new FakeConnection(1, async () => {
+      throw new Error("probe failed");
+    });
+    await expect(
+      createOsmixWorkerPool<TestWorker>({
+        workerCount: 2,
+        createWorker: (index) => [first, failed][index]!,
+      }),
+    ).rejects.toThrow("probe failed");
+    expect(first.terminate).toHaveBeenCalledOnce();
+    expect(failed.terminate).toHaveBeenCalledOnce();
+  });
+
+  it("caps automatic recovery at one restart per slot", async () => {
+    await expect(
+      createOsmixWorkerPool<TestWorker>({
+        workerCount: 1,
+        restartAttempts: 2,
+        createWorker: () => new FakeConnection(0),
+      }),
+    ).rejects.toThrow("restartAttempts cannot exceed one");
+  });
+
+  it("uses stable priority/FIFO ordering and keeps eligible idle workers busy", async () => {
+    const connections = [new FakeConnection(0), new FakeConnection(1)];
+    const pool = await createOsmixWorkerPool<TestWorker>({
+      workerCount: 2,
+      createWorker: (index) => connections[index]!,
+    });
+    const gate = deferred<void>();
+    const started: string[] = [];
+    const busy = pool.runOn(0, async () => {
+      started.push("busy");
+      await gate.promise;
+    });
+    await vi.waitFor(() => expect(pool.diagnostics().busyWorkerIndexes).toEqual([0]));
+
+    const pinned = pool.runOn(0, async () => started.push("pinned"), { priority: 100 });
+    const available = pool.run(async (_worker, index) => started.push(`available-${index}`));
+    await expect(available).resolves.toBe(2);
+    expect(started).toEqual(["busy", "available-1"]);
+
+    const low = pool.runOn(0, async () => started.push("low"));
+    const highOne = pool.runOn(0, async () => started.push("high-1"), { priority: 10 });
+    const highTwo = pool.runOn(0, async () => started.push("high-2"), { priority: 10 });
+    gate.resolve();
+    await Promise.all([busy, pinned, low, highOne, highTwo]);
+    expect(started).toEqual(["busy", "available-1", "pinned", "high-1", "high-2", "low"]);
+    await pool.dispose();
+  });
+
+  it("matches flexible work away from a slot required by an affinity task", async () => {
+    const connections = [new FakeConnection(0), new FakeConnection(1)];
+    const pool = await createOsmixWorkerPool<TestWorker>({
+      workerCount: 2,
+      createWorker: (index) => connections[index]!,
+    });
+    const flexible = pool.run(async (_worker, index) => index, { priority: 10 });
+    const control = pool.runOn(0, async (_worker, index) => index);
+    await expect(Promise.all([flexible, control])).resolves.toEqual([1, 0]);
+    await pool.dispose();
+  });
+
+  it("removes queued aborted work without disturbing the active operation", async () => {
+    const connection = new FakeConnection(0);
+    const pool = await createOsmixWorkerPool<TestWorker>({
+      workerCount: 1,
+      createWorker: () => connection,
+    });
+    const gate = deferred<void>();
+    const active = pool.run(async () => gate.promise);
+    await vi.waitFor(() => expect(pool.diagnostics().busyWorkerIndexes).toEqual([0]));
+    const controller = new AbortController();
+    const queued = pool.run(async () => "should not run", { signal: controller.signal });
+    expect(pool.diagnostics().queuedTaskCount).toBe(1);
+    controller.abort(new Error("stale request"));
+    await expect(queued).rejects.toThrow("stale request");
+    expect(pool.diagnostics().queuedTaskCount).toBe(0);
+    gate.resolve();
+    await active;
+    await pool.dispose();
+  });
+
+  it("restarts, restores, and explicitly retries timed-out work once", async () => {
+    const first = new FakeConnection(0);
+    const replacement = new FakeConnection(1);
+    const connections = [first, replacement];
+    const restoreWorker = vi.fn(async () => undefined);
+    const pool = await createOsmixWorkerPool<TestWorker>({
+      workerCount: 1,
+      createWorker: () => connections.shift()!,
+      probeTimeoutMs: 50,
+      restoreWorker,
+    });
+    let attempt = 0;
+    const result = pool.run(
+      async () => {
+        if (attempt++ === 0) return new Promise<number>(() => undefined);
+        return 42;
+      },
+      { retry: "once", timeoutMs: 5 },
+    );
+    await expect(result).resolves.toBe(42);
+    expect(first.terminate).toHaveBeenCalledOnce();
+    expect(restoreWorker).toHaveBeenCalledWith(replacement.remote, 0, 1);
+    expect(pool.diagnostics()).toMatchObject({ restartCount: 1, queuedTaskCount: 0 });
+    await pool.dispose();
+  });
+
+  it("surfaces a repeated failure after one restart", async () => {
+    const first = new FakeConnection(0);
+    const replacement = new FakeConnection(1);
+    const connections = [first, replacement];
+    const pool = await createOsmixWorkerPool<TestWorker>({
+      workerCount: 1,
+      createWorker: () => connections.shift()!,
+      probeTimeoutMs: 50,
+    });
+    const result = pool.run(async () => new Promise<number>(() => undefined), {
+      retry: "once",
+      timeoutMs: 5,
+    });
+    await expect(result).rejects.toBeInstanceOf(OsmixWorkerTaskTimeoutError);
+    await vi.waitFor(() => expect(pool.diagnostics().workers[0]?.state).toBe("failed"));
+    expect(pool.diagnostics().restartCount).toBe(1);
+    expect(first.terminate).toHaveBeenCalledOnce();
+    expect(replacement.terminate).toHaveBeenCalledOnce();
+    await pool.dispose();
+  });
+
+  it("retries worker failures but not ordinary operation errors", async () => {
+    const failed = new FakeConnection(0);
+    const replacement = new FakeConnection(1);
+    const connections = [failed, replacement];
+    const pool = await createOsmixWorkerPool<TestWorker>({
+      workerCount: 1,
+      createWorker: () => connections.shift()!,
+    });
+    let attempts = 0;
+    const recovered = pool.run(
+      async () => {
+        attempts++;
+        if (attempts === 1) {
+          queueMicrotask(() => failed.fail());
+          return new Promise<number>(() => undefined);
+        }
+        return 7;
+      },
+      { retry: "once" },
+    );
+    await expect(recovered).resolves.toBe(7);
+    await expect(
+      pool.run(
+        async () => {
+          throw new Error("invalid request");
+        },
+        { retry: "once" },
+      ),
+    ).rejects.toThrow("invalid request");
+    expect(attempts).toBe(2);
+    expect(pool.diagnostics().restartCount).toBe(1);
+    await pool.dispose();
+  });
+
+  it("does not retry worker failures unless the operation opts in", async () => {
+    const failed = new FakeConnection(0);
+    const replacement = new FakeConnection(1);
+    const connections = [failed, replacement];
+    const pool = await createOsmixWorkerPool<TestWorker>({
+      workerCount: 1,
+      createWorker: () => connections.shift()!,
+    });
+    let attempts = 0;
+    const result = pool.run(async () => {
+      attempts++;
+      queueMicrotask(() => failed.fail());
+      return new Promise<number>(() => undefined);
+    });
+    await expect(result).rejects.toThrow("worker crashed");
+    await vi.waitFor(() => expect(pool.diagnostics().restartCount).toBe(1));
+    expect(attempts).toBe(1);
+    await pool.dispose();
+  });
+
+  it("recovers an idle worker and withholds its slot until restoration completes", async () => {
+    const failed = new FakeConnection(0);
+    const replacement = new FakeConnection(1);
+    const connections = [failed, replacement];
+    const restoreGate = deferred<void>();
+    const pool = await createOsmixWorkerPool<TestWorker>({
+      workerCount: 1,
+      createWorker: () => connections.shift()!,
+      restoreWorker: async () => restoreGate.promise,
+    });
+    failed.fail();
+    await vi.waitFor(() => expect(pool.diagnostics().workers[0]?.state).toBe("restarting"));
+    let started = false;
+    const pending = pool.run(async (_worker, index) => {
+      started = true;
+      return index;
+    });
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    expect(started).toBe(false);
+    restoreGate.resolve();
+    await expect(pending).resolves.toBe(0);
+    expect(started).toBe(true);
+    expect(pool.diagnostics().restartCount).toBe(1);
+    await pool.dispose();
+  });
+
+  it("bounds restoration and preserves its timeout as the terminal slot error", async () => {
+    const failed = new FakeConnection(0);
+    const replacement = new FakeConnection(1);
+    const connections = [failed, replacement];
+    const pool = await createOsmixWorkerPool<TestWorker>({
+      workerCount: 1,
+      createWorker: () => connections.shift()!,
+      restoreTimeoutMs: 5,
+      restoreWorker: async () => new Promise<void>(() => undefined),
+    });
+    failed.fail();
+    const pending = pool.run(async () => 1);
+    await expect(pending).rejects.toBeInstanceOf(OsmixWorkerTaskTimeoutError);
+    expect(pool.diagnostics().workers[0]?.state).toBe("failed");
+    await pool.dispose();
+  });
+
+  it("surfaces the exact restoration failure to queued work", async () => {
+    const failed = new FakeConnection(0);
+    const replacement = new FakeConnection(1);
+    const recoveryError = new Error("durable dataset is unavailable");
+    const connections = [failed, replacement];
+    const pool = await createOsmixWorkerPool<TestWorker>({
+      workerCount: 1,
+      createWorker: () => connections.shift()!,
+      restoreWorker: async () => {
+        throw recoveryError;
+      },
+    });
+    failed.fail();
+    const pending = pool.run(async () => 1);
+    await expect(pending).rejects.toBe(recoveryError);
+    await pool.dispose();
+  });
+
+  it("does not hang when a replacement worker fails during restoration", async () => {
+    const failed = new FakeConnection(0);
+    const replacement = new FakeConnection(1);
+    const connections = [failed, replacement];
+    const pool = await createOsmixWorkerPool<TestWorker>({
+      workerCount: 1,
+      createWorker: () => connections.shift()!,
+      restoreWorker: () => {
+        queueMicrotask(() => replacement.fail(new Error("restore crashed")));
+      },
+    });
+    const result = pool.run(
+      async () => {
+        queueMicrotask(() => failed.fail());
+        return new Promise<number>(() => undefined);
+      },
+      { retry: "once" },
+    );
+    await expect(result).rejects.toThrow("restore crashed");
+    expect(pool.diagnostics().workers[0]?.state).toBe("failed");
+    await pool.dispose();
+  });
+
+  it("broadcasts in worker-index order and offers a deprecated unmanaged escape hatch", async () => {
+    const connections = [new FakeConnection(0), new FakeConnection(1), new FakeConnection(2)];
+    const pool = await createOsmixWorkerPool<TestWorker>({
+      workerCount: 3,
+      createWorker: (index) => connections[index]!,
+    });
+    await expect(pool.broadcast(async (_worker, index) => index)).resolves.toEqual([0, 1, 2]);
+    await expect(
+      pool.broadcast(async (_worker, index) => index, { eligibleWorkerIndexes: [1, 2] }),
+    ).resolves.toEqual([1, 2]);
+    expect(pool.getUnmanagedWorker()).toBe(connections[0]!.remote);
+    expect(pool.getUnmanagedWorker()).toBe(connections[1]!.remote);
+    expect(pool.getUnmanagedWorker(2)).toBe(connections[2]!.remote);
+    await pool.dispose();
+  });
+
+  it("disposes queued/running work and connections idempotently", async () => {
+    const connection = new FakeConnection(0);
+    const pool = await createOsmixWorkerPool<TestWorker>({
+      workerCount: 1,
+      createWorker: () => connection,
+    });
+    const running = pool.run(async () => new Promise<void>(() => undefined));
+    const queued = pool.run(async () => undefined);
+    await vi.waitFor(() => expect(pool.diagnostics().busyWorkerIndexes).toEqual([0]));
+    await Promise.all([pool.dispose(), pool.dispose()]);
+    await expect(running).rejects.toBeInstanceOf(OsmixWorkerPoolDisposedError);
+    await expect(queued).rejects.toBeInstanceOf(OsmixWorkerPoolDisposedError);
+    expect(connection.terminate).toHaveBeenCalledOnce();
+    expect(pool.diagnostics()).toMatchObject({ disposed: true, queuedTaskCount: 0 });
+  });
+
+  it("does not resurrect a slot when running work settles after disposal", async () => {
+    const connection = new FakeConnection(0);
+    const gate = deferred<void>();
+    const pool = await createOsmixWorkerPool<TestWorker>({
+      workerCount: 1,
+      createWorker: () => connection,
+    });
+    const running = pool.run(async () => gate.promise);
+    await vi.waitFor(() => expect(pool.diagnostics().busyWorkerIndexes).toEqual([0]));
+    await pool.dispose();
+    await expect(running).rejects.toBeInstanceOf(OsmixWorkerPoolDisposedError);
+    gate.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(pool.diagnostics().workers[0]?.state).toBe("disposed");
+  });
+
+  it("does not finish disposal until a delayed replacement is created and terminated", async () => {
+    const failed = new FakeConnection(0);
+    const replacement = new FakeConnection(1);
+    const replacementReady = deferred<OsmixWorkerConnection<TestWorker>>();
+    let createCount = 0;
+    const pool = await createOsmixWorkerPool<TestWorker>({
+      workerCount: 1,
+      createWorker: () => (createCount++ === 0 ? failed : replacementReady.promise),
+    });
+    failed.fail();
+    await vi.waitFor(() => expect(createCount).toBe(2));
+    let disposed = false;
+    const disposal = pool.dispose().then(() => {
+      disposed = true;
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(disposed).toBe(false);
+    replacementReady.resolve(replacement);
+    await disposal;
+    expect(replacement.terminate).toHaveBeenCalledOnce();
+    expect(disposed).toBe(true);
+    expect(pool.diagnostics().workers[0]?.state).toBe("disposed");
+  });
+});
+
+describe("Node worker runtime", () => {
+  it("keeps explicit in-process execution blocking and disposal idempotent", async () => {
+    const worker = new OsmixWorker();
+    const pool = await createOsmixWorkerPool({
+      inProcess: true,
+      createInProcessWorker: () => worker,
+      workerCount: 1,
+    });
+    expect(await pool.run((remote) => remote.ping())).toBe(true);
+    await Promise.all([pool.dispose(), pool.dispose()]);
+    expect(pool.diagnostics().disposed).toBe(true);
+  });
+
+  it("runs real worker threads without blocking the caller event loop", async () => {
+    const pool = await createOsmixWorkerPool<NodeTestWorker>({
+      workerCount: 2,
+      workerUrl: new URL("./fixtures/pool.worker.mjs", import.meta.url),
+      runtime: "node",
+    });
+    try {
+      const workerThreadIds = await pool.broadcast((worker) => worker.getThreadId());
+      expect(new Set(workerThreadIds).size).toBe(2);
+      expect(workerThreadIds).not.toContain(threadId);
+
+      let timerFired = false;
+      const timer = setTimeout(() => {
+        timerFired = true;
+      }, 5);
+      await pool.run((worker) => worker.block(50));
+      clearTimeout(timer);
+      expect(timerFired).toBe(true);
+    } finally {
+      await pool.dispose();
+    }
+  });
+
+  it("shares one backing buffer across real Node worker slots", async () => {
+    const pool = await createOsmixWorkerPool<NodeTestWorker>({
+      workerCount: 2,
+      workerUrl: new URL("./fixtures/pool.worker.mjs", import.meta.url),
+      runtime: "node",
+    });
+    try {
+      const buffer = new SharedArrayBuffer(4);
+      const local = new Uint8Array(buffer);
+      await expect(pool.broadcast((worker) => worker.installSharedBuffer(buffer))).resolves.toEqual(
+        [true, true],
+      );
+      await pool.runOn(0, (worker) => worker.writeSharedByte(0, 37));
+      await expect(pool.runOn(1, (worker) => worker.readSharedByte(0))).resolves.toBe(37);
+      expect(local[0]).toBe(37);
+    } finally {
+      await pool.dispose();
+    }
+  });
+
+  it("restarts a crashed Node worker and runs the explicit retry after restoration", async () => {
+    const restoreWorker = vi.fn(async () => undefined);
+    const pool = await createOsmixWorkerPool<NodeTestWorker>({
+      workerCount: 1,
+      workerUrl: new URL("./fixtures/pool.worker.mjs", import.meta.url),
+      runtime: "node",
+      restoreWorker,
+    });
+    try {
+      let attempts = 0;
+      const result = pool.run(
+        (worker) => (attempts++ === 0 ? worker.crash() : worker.getThreadId()),
+        { retry: "once", timeoutMs: 2_000 },
+      );
+      await expect(result).resolves.toBeGreaterThan(0);
+      expect(restoreWorker).toHaveBeenCalledOnce();
+      expect(pool.diagnostics().restartCount).toBe(1);
+    } finally {
+      await pool.dispose();
+    }
+  });
+});

--- a/packages/raster/README.md
+++ b/packages/raster/README.md
@@ -27,12 +27,16 @@ const tile = new OsmixRasterTile({
   tile: [9372, 12535, 15],
 });
 
-tile.drawPoint([-73.989, 40.733]);
-tile.drawLineString([
-  [-73.9892, 40.7326],
-  [-73.9887, 40.7331],
-  [-73.9883, 40.7336],
-]);
+tile.drawPoint([-73.989, 40.733], [255, 90, 90, 255], 2);
+tile.drawLineString(
+  [
+    [-73.9892, 40.7326],
+    [-73.9887, 40.7331],
+    [-73.9883, 40.7336],
+  ],
+  [255, 255, 255, 230],
+  3,
+);
 
 const canvas = new OffscreenCanvas(tile.tileSize, tile.tileSize);
 const ctx = canvas.getContext("2d");
@@ -63,8 +67,9 @@ constructor({ tile, tileSize = 256, imageData? })
 
 #### Drawing methods
 
-- `drawPoint(ll: [lon, lat], color?)`: Draw a single point.
-- `drawLineString(coords: [lon, lat][], color?)`: Draw a polyline.
+- `drawPoint(ll: [lon, lat], color?, radius = 0)`: Draw a point or filled circle.
+- `drawLine(px0, px1, color?, width = 1)`: Draw a pixel-space line with round caps and joins.
+- `drawLineString(coords: [lon, lat][], color?, width = 1)`: Draw a geographic polyline.
 - `drawPolygon(rings: [lon, lat][][], color?)`: Draw a filled polygon.
 - `drawRelation(polygons: [lon, lat][][][], color?)`: Draw a multipolygon relation.
 

--- a/packages/raster/src/raster-tile.ts
+++ b/packages/raster/src/raster-tile.ts
@@ -130,8 +130,50 @@ export class OsmixRasterTile {
     return (px[1] * this.tileSize + px[0]) * 4;
   }
 
-  drawPoint(ll: LonLat, color: Rgba = DEFAULT_POINT_COLOR) {
+  /** Draw a geographic point, optionally as a filled circle with a pixel radius. */
+  drawPoint(ll: LonLat, color: Rgba = DEFAULT_POINT_COLOR, radius = 0) {
     const px = this.llToTilePx(ll);
+    if (radius <= 0) {
+      this.drawPixel(px, color);
+      return;
+    }
+    this.drawCircle(this.clampAndRoundPx(px), color, radius);
+  }
+
+  /** Draw a filled circle in tile pixel coordinates. */
+  private drawCircle(center: XY, color: Rgba, radius: number) {
+    const normalizedRadius = Math.max(0, Math.round(radius));
+    const radiusSquared = normalizedRadius * normalizedRadius;
+    for (let y = -normalizedRadius; y <= normalizedRadius; y++) {
+      for (let x = -normalizedRadius; x <= normalizedRadius; x++) {
+        if (x * x + y * y > radiusSquared) continue;
+        this.drawPixelWithinTile([center[0] + x, center[1] + y], color);
+      }
+    }
+  }
+
+  /** Stamp a round brush centered on a tile pixel. */
+  private drawBrush(center: XY, color: Rgba, width: number) {
+    const normalizedWidth = Math.max(1, Math.round(width));
+    if (normalizedWidth === 1) {
+      this.drawPixelWithinTile(center, color);
+      return;
+    }
+
+    const radius = normalizedWidth / 2;
+    const centerOffset = normalizedWidth % 2 === 0 ? 0.5 : 0;
+    const min = -Math.floor((normalizedWidth - 1) / 2);
+    const max = Math.ceil((normalizedWidth - 1) / 2);
+    for (let y = min; y <= max; y++) {
+      for (let x = min; x <= max; x++) {
+        if (Math.hypot(x - centerOffset, y - centerOffset) > radius) continue;
+        this.drawPixelWithinTile([center[0] + x, center[1] + y], color);
+      }
+    }
+  }
+
+  private drawPixelWithinTile(px: XY, color: Rgba) {
+    if (px[0] < 0 || px[0] >= this.tileSize || px[1] < 0 || px[1] >= this.tileSize) return;
     this.drawPixel(px, color);
   }
 
@@ -176,9 +218,9 @@ export class OsmixRasterTile {
 
   /**
    * Draw a line between two pixels.
-   * Uses Bresenham's line algorithm.
+   * Uses Bresenham's line algorithm with round brushes for strokes wider than one pixel.
    */
-  drawLine(px0: XY, px1: XY, color: Rgba = DEFAULT_LINE_COLOR) {
+  drawLine(px0: XY, px1: XY, color: Rgba = DEFAULT_LINE_COLOR, width = 1) {
     const tileSize = this.tileSize;
     const dx = Math.abs(px1[0] - px0[0]);
     const dy = Math.abs(px1[1] - px0[1]);
@@ -191,7 +233,7 @@ export class OsmixRasterTile {
     while (true) {
       // Only draw pixels within tile bounds
       if (x >= 0 && x < tileSize && y >= 0 && y < tileSize) {
-        this.drawPixel([x, y], color);
+        this.drawBrush([x, y], color, width);
       }
       if (x === px1[0] && y === px1[1]) break;
       const e2 = 2 * err;
@@ -207,9 +249,9 @@ export class OsmixRasterTile {
   }
 
   /**
-   * Split a line string into a series of line segments and draw each segment.
+   * Split a line string into a series of line segments and draw it at a pixel width.
    */
-  drawLineString(coords: LonLat[], color: Rgba = DEFAULT_LINE_COLOR) {
+  drawLineString(coords: LonLat[], color: Rgba = DEFAULT_LINE_COLOR, width = 1) {
     const projectedCoords = coords.map((ll) => this.llToTilePx(ll));
     const [clipped] = clipPolyline(projectedCoords, [0, 0, this.tileSize, this.tileSize]);
     if (clipped != null) {
@@ -222,7 +264,7 @@ export class OsmixRasterTile {
         const px0 = this.clampAndRoundPx(prev);
         const px1 = this.clampAndRoundPx(curr);
         if (px0[0] !== px1[0] || px0[1] !== px1[1]) {
-          this.drawLine(px0, px1, color);
+          this.drawLine(px0, px1, color, width);
         }
         prev = curr;
       }

--- a/packages/raster/test/raster-tile.test.ts
+++ b/packages/raster/test/raster-tile.test.ts
@@ -23,6 +23,22 @@ describe("@osmix/raster: OsmixRasterTile", () => {
     expect(Array.from(tile.imageData.slice(idx, idx + 4))).toEqual(Array.from(DEFAULT_POINT_COLOR));
   });
 
+  it("preserves one-pixel point rendering by default and supports a radius", () => {
+    const tileIndex: Tile = [6, 7, 4];
+    const tileSize = 32;
+    const onePixel = new OsmixRasterTile({ tile: tileIndex, tileSize });
+    const circle = new OsmixRasterTile({ tile: tileIndex, tileSize });
+    const point = onePixel.tilePxToLonLat([16, 16]);
+
+    onePixel.drawPoint(point);
+    circle.drawPoint(point, DEFAULT_POINT_COLOR, 1);
+
+    expect(onePixel.imageData.filter((value, index) => index % 4 === 3 && value > 0)).toHaveLength(
+      1,
+    );
+    expect(circle.imageData.filter((value, index) => index % 4 === 3 && value > 0)).toHaveLength(5);
+  });
+
   it("draws clipped ways using Bresenham line rendering", () => {
     const tileIndex: Tile = [10, 11, 5];
     const tileSize = DEFAULT_RASTER_TILE_SIZE;
@@ -48,6 +64,40 @@ describe("@osmix/raster: OsmixRasterTile", () => {
     expect(Array.from(tile.imageData.slice(endIdx, endIdx + 3))).toEqual(
       Array.from(DEFAULT_LINE_COLOR.slice(0, -1)),
     );
+  });
+
+  it("preserves one-pixel line rendering and supports round thick strokes", () => {
+    const tileIndex: Tile = [10, 11, 5];
+    const tileSize = 64;
+    const defaultLine = new OsmixRasterTile({ tile: tileIndex, tileSize });
+    const explicitLine = new OsmixRasterTile({ tile: tileIndex, tileSize });
+    const thickLine = new OsmixRasterTile({ tile: tileIndex, tileSize });
+    const start: XY = [10, 20];
+    const end: XY = [30, 20];
+
+    defaultLine.drawLine(start, end);
+    explicitLine.drawLine(start, end, DEFAULT_LINE_COLOR, 1);
+    thickLine.drawLine(start, end, DEFAULT_LINE_COLOR, 3);
+
+    expect(explicitLine.imageData).toEqual(defaultLine.imageData);
+    for (const y of [19, 20, 21]) {
+      expect(thickLine.imageData[thickLine.getIndex([20, y]) + 3]).toBeGreaterThan(0);
+    }
+    expect(thickLine.imageData[thickLine.getIndex([9, 20]) + 3]).toBeGreaterThan(0);
+    expect(thickLine.imageData[thickLine.getIndex([31, 20]) + 3]).toBeGreaterThan(0);
+  });
+
+  it("clips thick strokes and composites overlapping alpha", () => {
+    const tile = new OsmixRasterTile({ tile: [10, 11, 5], tileSize: 16 });
+    const color: Rgba = [120, 160, 200, 96];
+
+    tile.drawLine([-4, 0], [4, 0], color, 5);
+    const alphaAfterFirstStroke = tile.imageData[tile.getIndex([2, 0]) + 3]!;
+    tile.drawLine([-4, 0], [4, 0], color, 5);
+
+    expect(tile.imageData.length).toBe(16 * 16 * 4);
+    expect(tile.imageData[tile.getIndex([2, 0]) + 3]).toBeGreaterThan(alphaAfterFirstStroke);
+    expect(tile.imageData[tile.getIndex([2, 4]) + 3]).toBe(0);
   });
 
   it("fills polygons using scanline algorithm", () => {

--- a/packages/shared/README.md
+++ b/packages/shared/README.md
@@ -1,5 +1,10 @@
 # @osmix/shared
 
+Dependency-free utilities shared by Osmix packages. Worker-capable consumers can use
+`runCooperatively` to split iterator work into event-loop slices, `GenerationGate` for
+generation-based cancellation with a SharedArrayBuffer fast path, and `inspectBackingBuffers` to
+verify backing-buffer identity and memory use.
+
 `@osmix/shared` hosts the low-level geometry, math, and infrastructure helpers
 used across every Osmix package. Modules are published via subpath exports, so
 import the functions you need directly from `@osmix/shared/<module>`.
@@ -21,24 +26,27 @@ pnpm add @osmix/shared
 
 ## Frequently used modules
 
-| Module                                | Description                                             |
-| ------------------------------------- | ------------------------------------------------------- |
-| `@osmix/shared/assert`                | Tiny invariant helpers that throw typed errors.         |
-| `@osmix/shared/bbox-intersects`       | Bounding-box intersection + containment checks.         |
-| `@osmix/shared/bytes-to-stream`       | Create a ReadableStream from a Uint8Array.              |
-| `@osmix/shared/coordinates`           | Utilities for coordinate precision (7 decimal places).  |
-| `@osmix/shared/haversine-distance`    | Great-circle distance (meters) for lon/lat pairs.       |
-| `@osmix/shared/lineclip`              | Typed wrapper around `lineclip` for polylines/polygons. |
-| `@osmix/shared/progress`              | Shared `ProgressEvent` helpers + `logProgress`.         |
-| `@osmix/shared/relation-kind`         | Detect relation types (multipolygon, route, etc).       |
-| `@osmix/shared/relation-multipolygon` | Builds multipolygon rings from relation members.        |
-| `@osmix/shared/stream-to-bytes`       | Consume a ReadableStream into a Uint8Array.             |
-| `@osmix/shared/throttle`              | Worker-safe throttling for logging/progress updates.    |
-| `@osmix/shared/tile`                  | Utilities for working with tile coordinates.            |
-| `@osmix/shared/transform-bytes`       | Transform streams (gzip, etc) helper.                   |
-| `@osmix/shared/utils`                 | General OSM entity utilities (equality, type checks).   |
-| `@osmix/shared/way-is-area`           | Implements the OSM wiki “is area” heuristics.           |
-| `@osmix/shared/zigzag`                | Protobuf-style zigzag encoding helpers.                 |
+| Module                                | Description                                              |
+| ------------------------------------- | -------------------------------------------------------- |
+| `@osmix/shared/assert`                | Tiny invariant helpers that throw typed errors.          |
+| `@osmix/shared/backing-buffers`       | Inspect shared, unique, and referenced backing bytes.    |
+| `@osmix/shared/bbox-intersects`       | Bounding-box intersection + containment checks.          |
+| `@osmix/shared/bytes-to-stream`       | Create a ReadableStream from a Uint8Array.               |
+| `@osmix/shared/coordinates`           | Utilities for coordinate precision (7 decimal places).   |
+| `@osmix/shared/cooperative`           | Run iterator work in cancellable 8 ms event-loop slices. |
+| `@osmix/shared/generation-gate`       | Atomic or RPC-updated generation cancellation.           |
+| `@osmix/shared/haversine-distance`    | Great-circle distance (meters) for lon/lat pairs.        |
+| `@osmix/shared/lineclip`              | Typed wrapper around `lineclip` for polylines/polygons.  |
+| `@osmix/shared/progress`              | Shared `ProgressEvent` helpers + `logProgress`.          |
+| `@osmix/shared/relation-kind`         | Detect relation types (multipolygon, route, etc).        |
+| `@osmix/shared/relation-multipolygon` | Builds multipolygon rings from relation members.         |
+| `@osmix/shared/stream-to-bytes`       | Consume a ReadableStream into a Uint8Array.              |
+| `@osmix/shared/throttle`              | Worker-safe throttling for logging/progress updates.     |
+| `@osmix/shared/tile`                  | Utilities for working with tile coordinates.             |
+| `@osmix/shared/transform-bytes`       | Transform streams (gzip, etc) helper.                    |
+| `@osmix/shared/utils`                 | General OSM entity utilities (equality, type checks).    |
+| `@osmix/shared/way-is-area`           | Implements the OSM wiki “is area” heuristics.            |
+| `@osmix/shared/zigzag`                | Protobuf-style zigzag encoding helpers.                  |
 
 All modules are tree-shakeable; only import what you need.
 

--- a/packages/shared/src/backing-buffers.test.ts
+++ b/packages/shared/src/backing-buffers.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { inspectBackingBuffers } from "./backing-buffers.ts";
+
+describe("inspectBackingBuffers", () => {
+  it("distinguishes references, identities, shared buffers, and bytes", () => {
+    const buffer = new ArrayBuffer(16);
+    const value: Record<string, unknown> = {
+      buffer,
+      view: new Uint8Array(buffer),
+    };
+    value["cycle"] = value;
+    if (typeof SharedArrayBuffer !== "undefined") {
+      value["shared"] = new Uint32Array(new SharedArrayBuffer(8));
+    }
+
+    const result = inspectBackingBuffers(value);
+    expect(result.references).toBe(typeof SharedArrayBuffer === "undefined" ? 2 : 3);
+    expect(result.unique).toBe(typeof SharedArrayBuffer === "undefined" ? 1 : 2);
+    expect(result.arrayBuffers).toBe(1);
+    expect(result.shared).toBe(typeof SharedArrayBuffer === "undefined" ? 0 : 1);
+    expect(result.uniqueBytes).toBe(typeof SharedArrayBuffer === "undefined" ? 16 : 24);
+    expect(result.referencedBytes).toBe(typeof SharedArrayBuffer === "undefined" ? 32 : 40);
+  });
+});

--- a/packages/shared/src/backing-buffers.ts
+++ b/packages/shared/src/backing-buffers.ts
@@ -1,0 +1,83 @@
+export interface BackingBufferInspection {
+  /** Total buffer references, including repeated views and repeated object properties. */
+  references: number;
+  /** Number of distinct backing buffers. */
+  unique: number;
+  /** Number of distinct SharedArrayBuffer instances. */
+  shared: number;
+  /** Number of distinct ArrayBuffer instances. */
+  arrayBuffers: number;
+  /** Bytes across distinct backing buffers. */
+  uniqueBytes: number;
+  /** Bytes counted once per reference. */
+  referencedBytes: number;
+}
+
+type BackingBuffer = ArrayBuffer | SharedArrayBuffer;
+
+function isBackingBuffer(value: unknown): value is BackingBuffer {
+  return (
+    value instanceof ArrayBuffer ||
+    (typeof SharedArrayBuffer !== "undefined" && value instanceof SharedArrayBuffer)
+  );
+}
+
+/** Inspect backing-buffer identity and byte usage in an arbitrarily nested value. */
+export function inspectBackingBuffers(value: unknown): BackingBufferInspection {
+  const visitedObjects = new WeakSet<object>();
+  const uniqueBuffers = new Set<BackingBuffer>();
+  let references = 0;
+  let referencedBytes = 0;
+
+  const visitBuffer = (buffer: BackingBuffer): void => {
+    references++;
+    referencedBytes += buffer.byteLength;
+    uniqueBuffers.add(buffer);
+  };
+
+  const visit = (candidate: unknown): void => {
+    if (isBackingBuffer(candidate)) {
+      visitBuffer(candidate);
+      return;
+    }
+    if (ArrayBuffer.isView(candidate)) {
+      visitBuffer(candidate.buffer);
+      return;
+    }
+    if ((typeof candidate !== "object" && typeof candidate !== "function") || !candidate) {
+      return;
+    }
+    if (visitedObjects.has(candidate)) return;
+    visitedObjects.add(candidate);
+    if (candidate instanceof Map) {
+      for (const [key, entry] of candidate) {
+        visit(key);
+        visit(entry);
+      }
+      return;
+    }
+    if (candidate instanceof Set) {
+      for (const entry of candidate) visit(entry);
+      return;
+    }
+    for (const entry of Object.values(candidate)) visit(entry);
+  };
+
+  visit(value);
+  let shared = 0;
+  let arrayBuffers = 0;
+  let uniqueBytes = 0;
+  for (const buffer of uniqueBuffers) {
+    uniqueBytes += buffer.byteLength;
+    if (typeof SharedArrayBuffer !== "undefined" && buffer instanceof SharedArrayBuffer) shared++;
+    else arrayBuffers++;
+  }
+  return {
+    references,
+    unique: uniqueBuffers.size,
+    shared,
+    arrayBuffers,
+    uniqueBytes,
+    referencedBytes,
+  };
+}

--- a/packages/shared/src/cooperative.test.ts
+++ b/packages/shared/src/cooperative.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { runCooperatively } from "./cooperative.ts";
+
+describe("runCooperatively", () => {
+  it("yields between bounded work slices and returns the iterator value", async () => {
+    let clock = 0;
+    const yielded = vi.fn(async () => undefined);
+    function* work(): Generator<void, string> {
+      for (let index = 0; index < 5; index++) {
+        clock += 3;
+        yield;
+      }
+      return "done";
+    }
+
+    await expect(
+      runCooperatively(work(), {
+        now: () => clock,
+        timeSliceMs: 5,
+        yieldToEventLoop: yielded,
+      }),
+    ).resolves.toEqual({ status: "completed", value: "done" });
+    expect(yielded).toHaveBeenCalledTimes(2);
+  });
+
+  it("closes the iterator when cancellation is observed", async () => {
+    let steps = 0;
+    let closed = false;
+    function* work(): Generator<void, void> {
+      try {
+        while (true) {
+          steps++;
+          yield;
+        }
+      } finally {
+        closed = true;
+      }
+    }
+
+    await expect(
+      runCooperatively(work(), {
+        isCancelled: () => steps >= 3,
+        now: () => steps,
+        timeSliceMs: 100,
+      }),
+    ).resolves.toEqual({ status: "cancelled" });
+    expect(closed).toBe(true);
+  });
+});

--- a/packages/shared/src/cooperative.ts
+++ b/packages/shared/src/cooperative.ts
@@ -1,0 +1,60 @@
+/** Result of running an iterator in cooperative event-loop slices. */
+export type CooperativeRunResult<T> = { status: "completed"; value: T } | { status: "cancelled" };
+
+export interface RunCooperativelyOptions {
+  /** Maximum synchronous work per slice. Defaults to 8 milliseconds. */
+  timeSliceMs?: number;
+  /** Monotonic clock seam for deterministic tests. */
+  now?: () => number;
+  /** Event-loop yield seam for deterministic tests and alternate runtimes. */
+  yieldToEventLoop?: () => Promise<void>;
+  /** Checked between iterator steps and before each event-loop yield. */
+  isCancelled?: () => boolean;
+}
+
+function currentTimeMs(): number {
+  return globalThis.performance?.now() ?? Date.now();
+}
+
+function yieldMacrotask(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+/**
+ * Run a synchronous iterator in bounded slices, yielding to the event loop between slices.
+ *
+ * The iterator should expose natural work boundaries by yielding regularly. Cancellation is
+ * cooperative: when observed, the iterator is closed and no further steps are evaluated.
+ */
+export async function runCooperatively<T>(
+  iterator: Iterator<unknown, T>,
+  options: RunCooperativelyOptions = {},
+): Promise<CooperativeRunResult<T>> {
+  const timeSliceMs = Math.max(0, options.timeSliceMs ?? 8);
+  const now = options.now ?? currentTimeMs;
+  const yieldToEventLoop = options.yieldToEventLoop ?? yieldMacrotask;
+  const isCancelled = options.isCancelled ?? (() => false);
+
+  while (true) {
+    if (isCancelled()) {
+      iterator.return?.();
+      return { status: "cancelled" };
+    }
+
+    const startedAt = now();
+    do {
+      if (isCancelled()) {
+        iterator.return?.();
+        return { status: "cancelled" };
+      }
+      const step = iterator.next();
+      if (step.done) return { status: "completed", value: step.value };
+    } while (now() - startedAt < timeSliceMs);
+
+    if (isCancelled()) {
+      iterator.return?.();
+      return { status: "cancelled" };
+    }
+    await yieldToEventLoop();
+  }
+}

--- a/packages/shared/src/generation-gate.test.ts
+++ b/packages/shared/src/generation-gate.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { GenerationGate } from "./generation-gate.ts";
+
+describe("GenerationGate", () => {
+  it("applies monotonic RPC updates in fallback mode", () => {
+    const gate = GenerationGate.create({ initialGeneration: 2, shared: false });
+    expect(gate.advance()).toBe(3);
+    expect(gate.update(1)).toBe(3);
+    expect(gate.update(5)).toBe(5);
+    expect(gate.isCancelled(4)).toBe(true);
+    expect(gate.isCurrent(5)).toBe(true);
+  });
+
+  it("shares atomic cancellation state across reconstructed gates", () => {
+    if (typeof SharedArrayBuffer === "undefined") return;
+    const dispatcher = GenerationGate.create({ initialGeneration: 7, shared: true });
+    const worker = GenerationGate.fromTransferables(dispatcher.transferables());
+    expect(worker.hasSharedState).toBe(true);
+    dispatcher.advance();
+    expect(worker.generation).toBe(8);
+    expect(worker.isCancelled(7)).toBe(true);
+  });
+
+  it("does not regress shared state when reconstructing from an older descriptor", () => {
+    if (typeof SharedArrayBuffer === "undefined") return;
+    const dispatcher = GenerationGate.create({ initialGeneration: 3, shared: true });
+    const descriptor = dispatcher.transferables();
+    dispatcher.update(9);
+
+    const worker = GenerationGate.fromTransferables(descriptor);
+    expect(worker.generation).toBe(9);
+    expect(dispatcher.generation).toBe(9);
+  });
+});

--- a/packages/shared/src/generation-gate.ts
+++ b/packages/shared/src/generation-gate.ts
@@ -1,0 +1,100 @@
+export interface GenerationGateOptions {
+  initialGeneration?: number;
+  /** Force shared or RPC-updated state. Defaults to SharedArrayBuffer availability. */
+  shared?: boolean;
+}
+
+export interface GenerationGateTransferables {
+  generation: number;
+  sharedGeneration?: SharedArrayBuffer;
+}
+
+const normalizeGeneration = (generation: number): number =>
+  Math.max(0, Math.min(0x7fff_ffff, Math.trunc(generation)));
+
+/**
+ * Monotonic generation-based cancellation shared between a dispatcher and worker jobs.
+ *
+ * SharedArrayBuffer runtimes observe advances immediately through Atomics. Other runtimes copy
+ * the current generation and call {@link update} through their existing RPC transport.
+ */
+export class GenerationGate {
+  private fallbackGeneration: number;
+  private readonly sharedGeneration: Int32Array<SharedArrayBuffer> | null;
+
+  private constructor(
+    generation: number,
+    sharedGeneration: Int32Array<SharedArrayBuffer> | null,
+    initializeSharedState: boolean,
+  ) {
+    this.fallbackGeneration = normalizeGeneration(generation);
+    this.sharedGeneration = sharedGeneration;
+    if (sharedGeneration && initializeSharedState) {
+      Atomics.store(sharedGeneration, 0, this.fallbackGeneration);
+    }
+  }
+
+  static create(options: GenerationGateOptions = {}): GenerationGate {
+    const generation = normalizeGeneration(options.initialGeneration ?? 0);
+    const useShared = options.shared ?? typeof SharedArrayBuffer !== "undefined";
+    if (!useShared) return new GenerationGate(generation, null, false);
+    if (typeof SharedArrayBuffer === "undefined") {
+      throw new Error("SharedArrayBuffer is unavailable in this runtime");
+    }
+    return new GenerationGate(generation, new Int32Array(new SharedArrayBuffer(4)), true);
+  }
+
+  static fromTransferables(transferables: GenerationGateTransferables): GenerationGate {
+    const sharedGeneration = transferables.sharedGeneration
+      ? new Int32Array(transferables.sharedGeneration)
+      : null;
+    // The descriptor may have been captured before the dispatcher advanced the shared value.
+    // Wrapping an existing SAB must never write that stale snapshot back into shared state.
+    return new GenerationGate(transferables.generation, sharedGeneration, false);
+  }
+
+  get generation(): number {
+    return this.sharedGeneration ? Atomics.load(this.sharedGeneration, 0) : this.fallbackGeneration;
+  }
+
+  get hasSharedState(): boolean {
+    return this.sharedGeneration !== null;
+  }
+
+  advance(): number {
+    const current = this.generation;
+    if (current === 0x7fff_ffff) throw new Error("Generation limit reached");
+    return this.update(current + 1);
+  }
+
+  /** Apply an RPC-delivered generation, ignoring stale updates. */
+  update(generation: number): number {
+    const next = normalizeGeneration(generation);
+    if (this.sharedGeneration) {
+      let current = Atomics.load(this.sharedGeneration, 0);
+      while (next > current) {
+        const previous = Atomics.compareExchange(this.sharedGeneration, 0, current, next);
+        if (previous === current) return next;
+        current = previous;
+      }
+      return current;
+    }
+    this.fallbackGeneration = Math.max(this.fallbackGeneration, next);
+    return this.fallbackGeneration;
+  }
+
+  isCurrent(generation: number): boolean {
+    return normalizeGeneration(generation) === this.generation;
+  }
+
+  isCancelled(generation: number): boolean {
+    return normalizeGeneration(generation) < this.generation;
+  }
+
+  transferables(): GenerationGateTransferables {
+    return {
+      generation: this.generation,
+      ...(this.sharedGeneration ? { sharedGeneration: this.sharedGeneration.buffer } : {}),
+    };
+  }
+}

--- a/packages/shortbread/README.md
+++ b/packages/shortbread/README.md
@@ -21,8 +21,30 @@ const osm = await fromPbf(pbfStream);
 const encoder = new ShortbreadVtEncoder(osm);
 
 // Generate a tile
-const tile = encoder.getTile([z, x, y]);
+const tile = encoder.getTile([x, y, z]);
 ```
+
+For repeated or concurrent tile generation, build the compact transferable classification index
+once and share its backing buffers with workers:
+
+```typescript
+import { ShortbreadFeatureIndex, ShortbreadVtEncoder } from "@osmix/shortbread";
+
+const featureIndex = ShortbreadFeatureIndex.build(osm);
+const encoder = new ShortbreadVtEncoder(osm, { featureIndex });
+```
+
+The existing positional `new ShortbreadVtEncoder(osm, extent, buffer, featureIndex)` form remains
+supported for compatibility.
+
+`featureIndex.transferables()` can be reconstructed with
+`ShortbreadFeatureIndex.fromTransferables()`. Its buffers use `SharedArrayBuffer` whenever the
+runtime supports it, so workers can share one index without cloning regional data.
+`featureIndex.query(bbox)` remains available, while the typed query form can prefilter records by
+entity kind, geometry mask, and Shortbread layer before materialization.
+Classified area relations suppress only the corresponding member-way layers they replace. Other
+independently classified layers on the same way remain available, and route membership never
+suppresses road geometry.
 
 ## Layers
 

--- a/packages/shortbread/package.json
+++ b/packages/shortbread/package.json
@@ -19,12 +19,15 @@
     "@osmix/core": "workspace:*",
     "@osmix/geo": "workspace:*",
     "@osmix/types": "workspace:*",
-    "@osmix/vt": "workspace:*"
+    "@osmix/vt": "workspace:*",
+    "flatbush": "^4.6.2"
   },
   "devDependencies": {
     "@mapbox/tilebelt": "^2.0.3",
     "@mapbox/vector-tile": "^3.0.0",
+    "@osmix/load": "workspace:*",
     "@osmix/shared": "workspace:*",
+    "@osmix/test-utils": "workspace:*",
     "pbf": "catalog:",
     "typescript": "catalog:"
   }

--- a/packages/shortbread/src/encoder.ts
+++ b/packages/shortbread/src/encoder.ts
@@ -17,11 +17,23 @@ import {
   writeVtPbf,
 } from "@osmix/vt";
 
+import {
+  shortbreadFeatureHasLayer,
+  type ShortbreadFeatureIndex,
+  type ShortbreadFeatureRecord,
+} from "./feature-index.ts";
 import { matchTags, SHORTBREAD_LAYERS } from "./layers.ts";
 import type { ShortbreadLayerName, ShortbreadProperties } from "./types.ts";
 
 const DEFAULT_EXTENT = 4096;
 const DEFAULT_BUFFER = 64;
+
+/** Named construction options for indexed or custom-extent Shortbread encoding. */
+export interface ShortbreadVtEncoderOptions {
+  buffer?: number;
+  extent?: number;
+  featureIndex?: ShortbreadFeatureIndex;
+}
 
 const SF_TYPE: VtSimpleFeatureType = {
   POINT: 1,
@@ -94,6 +106,15 @@ interface ClassifiedFeature {
   geometry: VtSimpleFeatureGeometry;
 }
 
+interface FeatureCandidate {
+  entityIndex: number;
+  layerMask?: number;
+}
+
+function* unindexedCandidates(indexes: Iterable<number>): Generator<FeatureCandidate> {
+  for (const entityIndex of [...indexes].sort((a, b) => a - b)) yield { entityIndex };
+}
+
 /**
  * Shortbread-compliant Vector Tile Encoder
  *
@@ -104,18 +125,40 @@ export class ShortbreadVtEncoder {
   private readonly osm: OsmReader;
   private readonly extent: number;
   private readonly extentBbox: [number, number, number, number];
+  private readonly featureIndex: ShortbreadFeatureIndex | undefined;
 
   /**
    * Create a new Shortbread encoder
    * @param osm - The OSM data source
    * @param extent - Tile extent (default 4096)
    * @param buffer - Buffer size for clipping (default 64)
+   * @param featureIndex - Optional preclassified, transferable spatial index
    */
-  constructor(osm: OsmReader, extent = DEFAULT_EXTENT, buffer = DEFAULT_BUFFER) {
+  constructor(osm: OsmReader, options?: ShortbreadVtEncoderOptions);
+  constructor(
+    osm: OsmReader,
+    extent?: number,
+    buffer?: number,
+    featureIndex?: ShortbreadFeatureIndex,
+  );
+  constructor(
+    osm: OsmReader,
+    extentOrOptions: number | ShortbreadVtEncoderOptions = DEFAULT_EXTENT,
+    buffer = DEFAULT_BUFFER,
+    featureIndex?: ShortbreadFeatureIndex,
+  ) {
+    const extent =
+      typeof extentOrOptions === "number"
+        ? extentOrOptions
+        : (extentOrOptions.extent ?? DEFAULT_EXTENT);
+    const resolvedBuffer =
+      typeof extentOrOptions === "number" ? buffer : (extentOrOptions.buffer ?? DEFAULT_BUFFER);
     this.osm = osm;
     this.extent = extent;
-    const min = -buffer;
-    const max = extent + buffer;
+    this.featureIndex =
+      typeof extentOrOptions === "number" ? featureIndex : extentOrOptions.featureIndex;
+    const min = -resolvedBuffer;
+    const max = extent + resolvedBuffer;
     this.extentBbox = [min, min, max, max];
   }
 
@@ -150,11 +193,19 @@ export class ShortbreadVtEncoder {
       featuresByLayer.set(layer.name, []);
     }
 
-    // Get way IDs that are part of relations
-    const relationWayIds = this.osm.relations.getWayMemberIds();
+    const indexedRecords = this.featureIndex?.query(bbox);
+    const nodeCandidates = this.candidates(indexedRecords, "node");
+    const wayCandidates = this.candidates(indexedRecords, "way");
+    const relationCandidates = this.candidates(indexedRecords, "relation");
+    const classifiedAreaMemberWayLayerMasks = this.featureIndex
+      ? null
+      : this.classifiedAreaMemberWayLayerMasks(bbox);
+    const suppressesWayLayer = (id: number, layer: ShortbreadLayerName): boolean =>
+      this.featureIndex?.suppressesWay(id, layer) ??
+      this.layerMaskHasLayer(classifiedAreaMemberWayLayerMasks?.get(id) ?? 0, layer);
 
     // Process nodes (points)
-    for (const feature of this.classifyNodes(bbox, proj)) {
+    for (const feature of this.classifyNodes(bbox, proj, nodeCandidates)) {
       const layerFeatures = featuresByLayer.get(feature.layer);
       if (layerFeatures) {
         layerFeatures.push(feature);
@@ -162,7 +213,7 @@ export class ShortbreadVtEncoder {
     }
 
     // Process ways (lines and polygons)
-    for (const feature of this.classifyWays(bbox, proj, relationWayIds)) {
+    for (const feature of this.classifyWays(bbox, proj, suppressesWayLayer, wayCandidates)) {
       const layerFeatures = featuresByLayer.get(feature.layer);
       if (layerFeatures) {
         layerFeatures.push(feature);
@@ -170,7 +221,7 @@ export class ShortbreadVtEncoder {
     }
 
     // Process relations
-    for (const feature of this.classifyRelations(bbox, proj)) {
+    for (const feature of this.classifyRelations(bbox, proj, relationCandidates)) {
       const layerFeatures = featuresByLayer.get(feature.layer);
       if (layerFeatures) {
         layerFeatures.push(feature);
@@ -222,10 +273,16 @@ export class ShortbreadVtEncoder {
   /**
    * Classify nodes into Shortbread layers
    */
-  private *classifyNodes(bbox: GeoBbox2D, proj: (ll: LonLat) => XY): Generator<ClassifiedFeature> {
-    const nodeIndexes = this.osm.nodes.findIndexesWithinBbox(bbox);
+  private *classifyNodes(
+    bbox: GeoBbox2D,
+    proj: (ll: LonLat) => XY,
+    indexedCandidates?: FeatureCandidate[],
+  ): Generator<ClassifiedFeature> {
+    const candidates =
+      indexedCandidates ?? unindexedCandidates(this.osm.nodes.findIndexesWithinBbox(bbox));
 
-    for (const nodeIndex of nodeIndexes) {
+    for (const candidate of candidates) {
+      const nodeIndex = candidate.entityIndex;
       const tags = this.osm.nodes.tags.getTags(nodeIndex);
       if (!tags || Object.keys(tags).length === 0) continue;
 
@@ -237,6 +294,12 @@ export class ShortbreadVtEncoder {
 
       const projected = proj(ll);
       for (const match of matches) {
+        if (
+          candidate.layerMask !== undefined &&
+          !shortbreadFeatureHasLayer({ layerMask: candidate.layerMask }, match.layer.name)
+        ) {
+          continue;
+        }
         yield {
           id,
           layer: match.layer.name,
@@ -254,14 +317,14 @@ export class ShortbreadVtEncoder {
   private *classifyWays(
     bbox: GeoBbox2D,
     proj: (ll: LonLat) => XY,
-    relationWayIds?: ReadonlySet<number>,
+    suppressesWayLayer: (id: number, layer: ShortbreadLayerName) => boolean,
+    indexedCandidates?: FeatureCandidate[],
   ): Generator<ClassifiedFeature> {
-    const wayIndexes = this.osm.ways.intersects(bbox);
+    const candidates = indexedCandidates ?? unindexedCandidates(this.osm.ways.intersects(bbox));
 
-    for (const wayIndex of wayIndexes) {
+    for (const candidate of candidates) {
+      const wayIndex = candidate.entityIndex;
       const id = this.osm.ways.ids.at(wayIndex);
-      // Skip ways that are part of relations
-      if (id !== undefined && relationWayIds?.has(id)) continue;
 
       const tags = this.osm.ways.tags.getTags(wayIndex);
       if (!tags || Object.keys(tags).length === 0) continue;
@@ -306,6 +369,13 @@ export class ShortbreadVtEncoder {
       if (geometry.length === 0) continue;
 
       for (const match of matches) {
+        if (isArea && suppressesWayLayer(id, match.layer.name)) continue;
+        if (
+          candidate.layerMask !== undefined &&
+          !shortbreadFeatureHasLayer({ layerMask: candidate.layerMask }, match.layer.name)
+        ) {
+          continue;
+        }
         yield {
           id,
           layer: match.layer.name,
@@ -323,10 +393,13 @@ export class ShortbreadVtEncoder {
   private *classifyRelations(
     bbox: GeoBbox2D,
     proj: (ll: LonLat) => XY,
+    indexedCandidates?: FeatureCandidate[],
   ): Generator<ClassifiedFeature> {
-    const relationIndexes = this.osm.relations.intersects(bbox);
+    const candidates =
+      indexedCandidates ?? unindexedCandidates(this.osm.relations.intersects(bbox));
 
-    for (const relIndex of relationIndexes) {
+    for (const candidate of candidates) {
+      const relIndex = candidate.entityIndex;
       const relation = this.osm.relations.getByIndex(relIndex);
       const relationGeometry = this.osm.relations.getRelationGeometry(relIndex);
       if (
@@ -364,6 +437,12 @@ export class ShortbreadVtEncoder {
           if (geometry.length === 0) continue;
 
           for (const match of matches) {
+            if (
+              candidate.layerMask !== undefined &&
+              !shortbreadFeatureHasLayer({ layerMask: candidate.layerMask }, match.layer.name)
+            ) {
+              continue;
+            }
             yield {
               id: relation.id,
               layer: match.layer.name,
@@ -397,6 +476,12 @@ export class ShortbreadVtEncoder {
           if (geometry.length === 0) continue;
 
           for (const match of matches) {
+            if (
+              candidate.layerMask !== undefined &&
+              !shortbreadFeatureHasLayer({ layerMask: candidate.layerMask }, match.layer.name)
+            ) {
+              continue;
+            }
             yield {
               id: relation.id,
               layer: match.layer.name,
@@ -424,6 +509,12 @@ export class ShortbreadVtEncoder {
         if (geometry.length === 0) continue;
 
         for (const match of matches) {
+          if (
+            candidate.layerMask !== undefined &&
+            !shortbreadFeatureHasLayer({ layerMask: candidate.layerMask }, match.layer.name)
+          ) {
+            continue;
+          }
           yield {
             id: relation.id,
             layer: match.layer.name,
@@ -434,6 +525,42 @@ export class ShortbreadVtEncoder {
         }
       }
     }
+  }
+
+  private candidates(
+    records: ShortbreadFeatureRecord[] | undefined,
+    entityType: ShortbreadFeatureRecord["entityType"],
+  ): FeatureCandidate[] | undefined {
+    return records
+      ?.filter((record) => record.entityType === entityType)
+      .map((record) => ({ entityIndex: record.entityIndex, layerMask: record.layerMask }));
+  }
+
+  /** Map members to only the layers supplied by classified area relations, never routes. */
+  private classifiedAreaMemberWayLayerMasks(bbox: GeoBbox2D): ReadonlyMap<number, number> {
+    const masks = new Map<number, number>();
+    for (const relationIndex of this.osm.relations.intersects(bbox)) {
+      const relation = this.osm.relations.getByIndex(relationIndex);
+      if (!relation.tags) continue;
+      const matches = matchTags(relation.tags, "Polygon");
+      if (matches.length === 0) continue;
+      const geometry = this.osm.relations.getRelationGeometry(relationIndex);
+      if (!geometry.rings || geometry.rings.length === 0) continue;
+      let relationLayerMask = 0;
+      for (const match of matches) {
+        const bit = SHORTBREAD_LAYERS.findIndex((layer) => layer.name === match.layer.name);
+        if (bit >= 0) relationLayerMask = (relationLayerMask | (1 << bit)) >>> 0;
+      }
+      for (const member of this.osm.relations.getMembersByIndex(relationIndex)) {
+        if (member.type !== "way") continue;
+        masks.set(member.ref, ((masks.get(member.ref) ?? 0) | relationLayerMask) >>> 0);
+      }
+    }
+    return masks;
+  }
+
+  private layerMaskHasLayer(mask: number, layer: ShortbreadLayerName): boolean {
+    return shortbreadFeatureHasLayer({ layerMask: mask }, layer);
   }
 
   private clipProjectedPolyline(points: XY[]): XY[][] {

--- a/packages/shortbread/src/feature-index.test.ts
+++ b/packages/shortbread/src/feature-index.test.ts
@@ -1,0 +1,252 @@
+import { pointToTile } from "@mapbox/tilebelt";
+import { VectorTile } from "@mapbox/vector-tile";
+import { Osm } from "@osmix/core";
+import { fromPbf } from "@osmix/load";
+import { inspectBackingBuffers } from "@osmix/shared/backing-buffers";
+import { getFixtureFileReadStream, PBFs } from "@osmix/test-utils/fixtures";
+import type { GeoBbox2D, Tile } from "@osmix/types";
+import { PbfReader } from "pbf";
+import { describe, expect, it } from "vitest";
+
+import { ShortbreadVtEncoder } from "./encoder.ts";
+import {
+  getShortbreadFeatureIndexBuffers,
+  SHORTBREAD_GEOMETRY_MASK,
+  shortbreadFeatureHasLayer,
+  ShortbreadFeatureIndex,
+} from "./feature-index.ts";
+
+function bboxToTile(bbox: GeoBbox2D, z = 14): Tile {
+  const [minX, minY, maxX, maxY] = bbox;
+  return pointToTile((minX + maxX) / 2, (minY + maxY) / 2, z);
+}
+
+function decodeTile(data: ArrayBuffer) {
+  return new VectorTile(new PbfReader(data)).layers;
+}
+
+function decodedTileSnapshot(data: ArrayBuffer) {
+  const layers = decodeTile(data);
+  return Object.fromEntries(
+    Object.entries(layers).map(([name, layer]) => [
+      name,
+      Array.from({ length: layer.length }, (_, index) => {
+        const feature = layer.feature(index);
+        return {
+          geometry: feature.loadGeometry(),
+          id: feature.id,
+          properties: feature.properties,
+          type: feature.type,
+        };
+      }),
+    ]),
+  );
+}
+
+function createMixedOsm(): Osm {
+  const osm = new Osm();
+  osm.nodes.addNode({
+    id: 1,
+    lat: 40.7,
+    lon: -74,
+    tags: { amenity: "restaurant", name: "Cafe" },
+  });
+  osm.nodes.addNode({ id: 2, lat: 40.7, lon: -74.01 });
+  osm.nodes.addNode({ id: 3, lat: 40.71, lon: -74.01 });
+  osm.nodes.addNode({ id: 4, lat: 40.71, lon: -74 });
+  osm.nodes.addNode({ id: 5, lat: 40.705, lon: -74.005, tags: { unknown: "value" } });
+  osm.ways.addWay({
+    id: 10,
+    refs: [2, 3, 4, 2],
+    tags: { building: "yes", name: "Indexed Building" },
+  });
+  osm.buildIndexes();
+  osm.buildSpatialIndexes();
+  return osm;
+}
+
+describe("ShortbreadFeatureIndex", () => {
+  it("stores only classified candidates and answers spatial queries", () => {
+    const osm = createMixedOsm();
+    const index = ShortbreadFeatureIndex.build(osm);
+    const records = index.query(osm.bbox());
+
+    expect(index.size).toBe(2);
+    expect(records.map((record) => record.entityType)).toEqual(["node", "way"]);
+    expect(shortbreadFeatureHasLayer(records[0]!, "pois")).toBe(true);
+    expect(shortbreadFeatureHasLayer(records[1]!, "buildings")).toBe(true);
+    expect(index.queryEntityIndexes(osm.bbox(), "node")).toEqual([0]);
+    expect(index.queryEntityIndexes(osm.bbox(), "way", (entityIndex) => entityIndex > 0)).toEqual(
+      [],
+    );
+    expect(index.query([0, 0, 1, 1])).toEqual([]);
+  });
+
+  it("filters query records before materializing them", () => {
+    const osm = createMixedOsm();
+    const index = ShortbreadFeatureIndex.build(osm);
+    const bbox = osm.bbox();
+
+    expect(index.query({ bbox })).toEqual(index.query(bbox));
+    const buildings = index.query({
+      bbox,
+      entityTypes: ["way"],
+      geometryMask: SHORTBREAD_GEOMETRY_MASK.POLYGON,
+      layers: ["buildings"],
+    });
+
+    expect(buildings).toHaveLength(1);
+    expect(buildings[0]?.entityType).toBe("way");
+    expect(shortbreadFeatureHasLayer(buildings[0]!, "buildings")).toBe(true);
+    expect(index.query({ bbox, entityTypes: ["node"], layers: ["buildings"] })).toHaveLength(0);
+  });
+
+  it("round-trips transferable state without copying shared buffers", () => {
+    const index = ShortbreadFeatureIndex.build(createMixedOsm());
+    const transferables = index.transferables();
+    const restored = ShortbreadFeatureIndex.fromTransferables(transferables);
+    const buffers = getShortbreadFeatureIndexBuffers(transferables);
+
+    expect(restored.query([-180, -90, 180, 90])).toEqual(index.query([-180, -90, 180, 90]));
+    expect(restored.backingBuffers()).toEqual(buffers);
+    expect(new Set(buffers).size).toBe(buffers.length);
+    const inspection = inspectBackingBuffers({ original: transferables, restored });
+    expect(inspection.unique).toBe(buffers.length);
+    if (typeof SharedArrayBuffer !== "undefined") {
+      expect(buffers.every((buffer) => buffer instanceof SharedArrayBuffer)).toBe(true);
+      expect(inspection.shared).toBe(buffers.length);
+    }
+  });
+
+  it("produces byte-identical tiles through the optional indexed encoder path", () => {
+    const osm = createMixedOsm();
+    const tile = bboxToTile(osm.bbox());
+    const featureIndex = ShortbreadFeatureIndex.build(osm);
+    const unindexed = new Uint8Array(new ShortbreadVtEncoder(osm).getTile(tile));
+    const indexed = new Uint8Array(
+      new ShortbreadVtEncoder(osm, 4096, 64, featureIndex).getTile(tile),
+    );
+    const indexedWithOptions = new Uint8Array(
+      new ShortbreadVtEncoder(osm, { featureIndex }).getTile(tile),
+    );
+
+    expect(indexed).toEqual(unindexed);
+    expect(indexedWithOptions).toEqual(unindexed);
+  });
+
+  it("matches Monaco tile bytes across overview and detailed zooms", async () => {
+    const osm = await fromPbf(getFixtureFileReadStream(PBFs["monaco"]!.url));
+    const featureIndex = ShortbreadFeatureIndex.build(osm);
+    const unindexed = new ShortbreadVtEncoder(osm);
+    const indexed = new ShortbreadVtEncoder(osm, { featureIndex });
+
+    for (const zoom of [10, 14]) {
+      const tile = bboxToTile(osm.bbox(), zoom);
+      const indexedTile = indexed.getTile(tile);
+      const unindexedTile = unindexed.getTile(tile);
+      expect(new Uint8Array(indexedTile)).toEqual(new Uint8Array(unindexedTile));
+      expect(decodedTileSnapshot(indexedTile)).toEqual(decodedTileSnapshot(unindexedTile));
+    }
+  });
+
+  it("suppresses a member area only when its classified relation supplies the geometry", () => {
+    const osm = new Osm();
+    osm.nodes.addNode({ id: 1, lat: 40.7, lon: -74 });
+    osm.nodes.addNode({ id: 2, lat: 40.71, lon: -74 });
+    osm.nodes.addNode({ id: 3, lat: 40.71, lon: -74.01 });
+    osm.nodes.addNode({ id: 4, lat: 40.7, lon: -74.01 });
+    osm.ways.addWay({
+      id: 10,
+      refs: [1, 2, 3, 4, 1],
+      tags: { natural: "water", name: "Member Lake" },
+    });
+    osm.relations.addRelation({
+      id: 20,
+      members: [{ type: "way", ref: 10, role: "outer" }],
+      tags: { type: "multipolygon", natural: "water", name: "Relation Lake" },
+    });
+    osm.buildIndexes();
+    osm.buildSpatialIndexes();
+    const index = ShortbreadFeatureIndex.build(osm);
+
+    expect(index.suppressesWay(10)).toBe(true);
+    expect(index.suppressesWay(10, "water")).toBe(true);
+    expect(index.suppressesWay(10, "sites")).toBe(false);
+    for (const encoder of [
+      new ShortbreadVtEncoder(osm),
+      new ShortbreadVtEncoder(osm, 4096, 64, index),
+    ]) {
+      const layers = decodeTile(encoder.getTile(bboxToTile(osm.bbox())));
+      expect(layers["water"]?.length).toBe(1);
+      expect(layers["water"]?.feature(0).properties["name"]).toBe("Relation Lake");
+    }
+  });
+
+  it("retains independent member layers not supplied by the area relation", () => {
+    const osm = new Osm();
+    osm.nodes.addNode({ id: 1, lat: 40.7, lon: -74 });
+    osm.nodes.addNode({ id: 2, lat: 40.71, lon: -74 });
+    osm.nodes.addNode({ id: 3, lat: 40.71, lon: -74.01 });
+    osm.nodes.addNode({ id: 4, lat: 40.7, lon: -74.01 });
+    osm.ways.addWay({
+      id: 10,
+      refs: [1, 2, 3, 4, 1],
+      tags: { natural: "water", leisure: "park", name: "Member Park Lake" },
+    });
+    osm.relations.addRelation({
+      id: 20,
+      members: [{ type: "way", ref: 10, role: "outer" }],
+      tags: { type: "multipolygon", natural: "water", name: "Relation Lake" },
+    });
+    osm.buildIndexes();
+    osm.buildSpatialIndexes();
+
+    const index = ShortbreadFeatureIndex.build(osm);
+    const restored = ShortbreadFeatureIndex.fromTransferables(index.transferables());
+    const tile = bboxToTile(osm.bbox());
+    const unindexed = new Uint8Array(new ShortbreadVtEncoder(osm).getTile(tile));
+    const indexed = new Uint8Array(
+      new ShortbreadVtEncoder(osm, { featureIndex: restored }).getTile(tile),
+    );
+
+    expect(restored.suppressedLayerMaskForWay(10)).not.toBe(0);
+    expect(restored.suppressesWay(10, "water")).toBe(true);
+    expect(restored.suppressesWay(10, "sites")).toBe(false);
+    expect(indexed).toEqual(unindexed);
+
+    const layers = decodeTile(indexed.buffer as ArrayBuffer);
+    expect(layers["water"]?.length).toBe(1);
+    expect(layers["water"]?.feature(0).properties["name"]).toBe("Relation Lake");
+    expect(layers["sites"]?.length).toBe(1);
+    expect(layers["sites"]?.feature(0).properties["name"]).toBe("Member Park Lake");
+  });
+
+  it("does not suppress a valid road because it belongs to a route relation", () => {
+    const osm = new Osm();
+    osm.nodes.addNode({ id: 1, lat: 40.7, lon: -74 });
+    osm.nodes.addNode({ id: 2, lat: 40.71, lon: -74.01 });
+    osm.ways.addWay({
+      id: 10,
+      refs: [1, 2],
+      tags: { highway: "primary", name: "Main Street" },
+    });
+    osm.relations.addRelation({
+      id: 20,
+      members: [{ type: "way", ref: 10, role: "" }],
+      tags: { type: "route", route: "bus", name: "Bus 1" },
+    });
+    osm.buildIndexes();
+    osm.buildSpatialIndexes();
+    const index = ShortbreadFeatureIndex.build(osm);
+
+    expect(index.suppressesWay(10)).toBe(false);
+    expect(index.suppressesWay(10, "streets")).toBe(false);
+    for (const encoder of [
+      new ShortbreadVtEncoder(osm),
+      new ShortbreadVtEncoder(osm, 4096, 64, index),
+    ]) {
+      const layers = decodeTile(encoder.getTile(bboxToTile(osm.bbox())));
+      expect(layers["streets"]?.length).toBe(1);
+    }
+  });
+});

--- a/packages/shortbread/src/feature-index.ts
+++ b/packages/shortbread/src/feature-index.ts
@@ -1,0 +1,415 @@
+import { BufferConstructor, type BufferType, type OsmReader } from "@osmix/core";
+import { wayIsArea } from "@osmix/geo/way-is-area";
+import type { GeoBbox2D, OsmTags } from "@osmix/types";
+import { isAreaRelation, isLineRelation, isPointRelation } from "@osmix/types/relation-kind";
+import Flatbush from "flatbush";
+
+import { matchTags, SHORTBREAD_LAYERS } from "./layers.ts";
+import type { ShortbreadGeometryType, ShortbreadLayerName } from "./types.ts";
+
+export const SHORTBREAD_GEOMETRY_MASK = {
+  POINT: 1,
+  LINE_STRING: 2,
+  POLYGON: 4,
+} as const;
+
+const ENTITY_TYPE = {
+  NODE: 0,
+  WAY: 1,
+  RELATION: 2,
+} as const;
+
+type EncodedEntityType = (typeof ENTITY_TYPE)[keyof typeof ENTITY_TYPE];
+
+export type ShortbreadFeatureEntityType = "node" | "way" | "relation";
+
+export interface ShortbreadFeatureRecord {
+  entityIndex: number;
+  entityType: ShortbreadFeatureEntityType;
+  geometryMask: number;
+  layerMask: number;
+  bbox: GeoBbox2D;
+}
+
+/** Spatial and semantic filters evaluated before feature records are materialized. */
+export interface ShortbreadFeatureQuery {
+  bbox: GeoBbox2D;
+  /** Include records matching any listed entity kind. Defaults to every kind. */
+  entityTypes?: readonly ShortbreadFeatureEntityType[];
+  /** Include records sharing at least one requested geometry bit. */
+  geometryMask?: number;
+  /** Include records classified into at least one requested Shortbread layer. */
+  layers?: readonly ShortbreadLayerName[];
+}
+
+export interface ShortbreadFeatureIndexTransferables<T extends BufferType = BufferType> {
+  bboxes: T;
+  entityIndexes: T;
+  entityTypes: T;
+  geometryMasks: T;
+  layerMasks: T;
+  spatialIndex?: T;
+  suppressedAreaWayIds: T;
+  /** Layer masks aligned with `suppressedAreaWayIds`. Absent only in legacy descriptors. */
+  suppressedAreaWayLayerMasks?: T;
+}
+
+interface MutableRecord {
+  bbox: GeoBbox2D;
+  entityIndex: number;
+  entityType: EncodedEntityType;
+  geometryMask: number;
+  layerMask: number;
+}
+
+const geometryMaskByType: Record<ShortbreadGeometryType, number> = {
+  Point: SHORTBREAD_GEOMETRY_MASK.POINT,
+  LineString: SHORTBREAD_GEOMETRY_MASK.LINE_STRING,
+  Polygon: SHORTBREAD_GEOMETRY_MASK.POLYGON,
+};
+
+const layerBits = new Map<ShortbreadLayerName, number>(
+  SHORTBREAD_LAYERS.map((layer, index) => [layer.name, (1 << index) >>> 0]),
+);
+
+function sharedUint8(values: number[]): Uint8Array<BufferType> {
+  const result = new Uint8Array(new BufferConstructor(values.length));
+  result.set(values);
+  return result;
+}
+
+function sharedUint32(values: number[]): Uint32Array<BufferType> {
+  const result = new Uint32Array(
+    new BufferConstructor(values.length * Uint32Array.BYTES_PER_ELEMENT),
+  );
+  result.set(values);
+  return result;
+}
+
+function sharedFloat64(values: number[]): Float64Array<BufferType> {
+  const result = new Float64Array(
+    new BufferConstructor(values.length * Float64Array.BYTES_PER_ELEMENT),
+  );
+  result.set(values);
+  return result;
+}
+
+function layerMask(tags: OsmTags, geometryType: ShortbreadGeometryType): number {
+  let mask = 0;
+  for (const match of matchTags(tags, geometryType)) {
+    mask = (mask | (layerBits.get(match.layer.name) ?? 0)) >>> 0;
+  }
+  return mask;
+}
+
+function validBbox(bbox: GeoBbox2D): boolean {
+  return bbox.every(Number.isFinite) && bbox[0] <= bbox[2] && bbox[1] <= bbox[3];
+}
+
+function entityTypeName(value: EncodedEntityType): ShortbreadFeatureEntityType {
+  if (value === ENTITY_TYPE.NODE) return "node";
+  if (value === ENTITY_TYPE.WAY) return "way";
+  return "relation";
+}
+
+function encodedEntityType(value: ShortbreadFeatureEntityType): EncodedEntityType {
+  if (value === "node") return ENTITY_TYPE.NODE;
+  if (value === "way") return ENTITY_TYPE.WAY;
+  return ENTITY_TYPE.RELATION;
+}
+
+function queryLayerMask(layers: readonly ShortbreadLayerName[] | undefined): number | undefined {
+  if (!layers) return undefined;
+  let mask = 0;
+  for (const layer of layers) mask = (mask | (layerBits.get(layer) ?? 0)) >>> 0;
+  return mask;
+}
+
+/** Return every distinct backing buffer used by serialized index state. */
+export function getShortbreadFeatureIndexBuffers(
+  transferables: ShortbreadFeatureIndexTransferables,
+): BufferType[] {
+  return [
+    transferables.bboxes,
+    transferables.entityIndexes,
+    transferables.entityTypes,
+    transferables.geometryMasks,
+    transferables.layerMasks,
+    ...(transferables.spatialIndex ? [transferables.spatialIndex] : []),
+    transferables.suppressedAreaWayIds,
+    ...(transferables.suppressedAreaWayLayerMasks
+      ? [transferables.suppressedAreaWayLayerMasks]
+      : []),
+  ];
+}
+
+/** Compact transferable classification and spatial index for Shortbread candidates. */
+export class ShortbreadFeatureIndex {
+  readonly size: number;
+  private readonly bboxes: Float64Array<BufferType>;
+  private readonly entityIndexes: Uint32Array<BufferType>;
+  private readonly entityTypes: Uint8Array<BufferType>;
+  private readonly geometryMasks: Uint8Array<BufferType>;
+  private readonly layerMasks: Uint32Array<BufferType>;
+  private readonly spatialIndex: Flatbush | null;
+  private readonly suppressedAreaWayIds: Float64Array<BufferType>;
+  private readonly suppressedAreaWayLayerMasks: Uint32Array<BufferType>;
+
+  private constructor(
+    bboxes: Float64Array<BufferType>,
+    entityIndexes: Uint32Array<BufferType>,
+    entityTypes: Uint8Array<BufferType>,
+    geometryMasks: Uint8Array<BufferType>,
+    layerMasks: Uint32Array<BufferType>,
+    spatialIndex: Flatbush | null,
+    suppressedAreaWayIds: Float64Array<BufferType>,
+    suppressedAreaWayLayerMasks: Uint32Array<BufferType>,
+  ) {
+    this.bboxes = bboxes;
+    this.entityIndexes = entityIndexes;
+    this.entityTypes = entityTypes;
+    this.geometryMasks = geometryMasks;
+    this.layerMasks = layerMasks;
+    this.spatialIndex = spatialIndex;
+    this.suppressedAreaWayIds = suppressedAreaWayIds;
+    this.suppressedAreaWayLayerMasks = suppressedAreaWayLayerMasks;
+    this.size = entityIndexes.length;
+  }
+
+  static build(osm: OsmReader): ShortbreadFeatureIndex {
+    const records: MutableRecord[] = [];
+    const suppressedAreaWayLayerMasks = new Map<number, number>();
+
+    for (let entityIndex = 0; entityIndex < osm.nodes.size; entityIndex++) {
+      if (osm.nodes.tags.cardinality(entityIndex) === 0) continue;
+      const tags = osm.nodes.tags.getTags(entityIndex);
+      if (!tags) continue;
+      const mask = layerMask(tags, "Point");
+      if (mask === 0) continue;
+      const bbox = osm.nodes.getEntityBbox({ index: entityIndex });
+      if (!validBbox(bbox)) continue;
+      records.push({
+        bbox,
+        entityIndex,
+        entityType: ENTITY_TYPE.NODE,
+        geometryMask: SHORTBREAD_GEOMETRY_MASK.POINT,
+        layerMask: mask,
+      });
+    }
+
+    for (let entityIndex = 0; entityIndex < osm.ways.size; entityIndex++) {
+      if (osm.ways.tags.cardinality(entityIndex) === 0) continue;
+      const tags = osm.ways.tags.getTags(entityIndex);
+      if (!tags) continue;
+      const id = osm.ways.ids.at(entityIndex);
+      const isArea = wayIsArea({
+        id,
+        refs: osm.ways.getRefIds(entityIndex),
+        tags,
+      });
+      const geometryType = isArea ? "Polygon" : "LineString";
+      const mask = layerMask(tags, geometryType);
+      if (mask === 0) continue;
+      const bbox = osm.ways.getEntityBbox({ index: entityIndex });
+      if (!validBbox(bbox)) continue;
+      records.push({
+        bbox,
+        entityIndex,
+        entityType: ENTITY_TYPE.WAY,
+        geometryMask: geometryMaskByType[geometryType],
+        layerMask: mask,
+      });
+    }
+
+    for (let entityIndex = 0; entityIndex < osm.relations.size; entityIndex++) {
+      if (osm.relations.tags.cardinality(entityIndex) === 0) continue;
+      const relation = osm.relations.getByIndex(entityIndex);
+      const tags = relation.tags;
+      if (!tags) continue;
+
+      let geometryType: ShortbreadGeometryType | null = null;
+      if (isAreaRelation(relation)) geometryType = "Polygon";
+      else if (isLineRelation(relation)) geometryType = "LineString";
+      else if (isPointRelation(relation)) geometryType = "Point";
+      if (!geometryType) continue;
+
+      const mask = layerMask(tags, geometryType);
+      if (mask === 0) continue;
+      const geometry = osm.relations.getRelationGeometry(entityIndex);
+      const suppliesGeometry =
+        (geometryType === "Polygon" && (geometry.rings?.length ?? 0) > 0) ||
+        (geometryType === "LineString" && (geometry.lineStrings?.length ?? 0) > 0) ||
+        (geometryType === "Point" && (geometry.points?.length ?? 0) > 0);
+      if (!suppliesGeometry) continue;
+
+      const bbox = osm.relations.getEntityBbox({ index: entityIndex });
+      if (!validBbox(bbox)) continue;
+      records.push({
+        bbox,
+        entityIndex,
+        entityType: ENTITY_TYPE.RELATION,
+        geometryMask: geometryMaskByType[geometryType],
+        layerMask: mask,
+      });
+
+      if (geometryType === "Polygon") {
+        for (const member of osm.relations.getMembersByIndex(entityIndex)) {
+          if (member.type !== "way") continue;
+          const previousMask = suppressedAreaWayLayerMasks.get(member.ref) ?? 0;
+          suppressedAreaWayLayerMasks.set(member.ref, (previousMask | mask) >>> 0);
+        }
+      }
+    }
+
+    const bboxes = records.flatMap((record) => record.bbox);
+    let spatialIndex: Flatbush | null = null;
+    if (records.length > 0) {
+      spatialIndex = new Flatbush(records.length, 64, Float64Array, BufferConstructor);
+      for (const record of records) spatialIndex.add(...record.bbox);
+      spatialIndex.finish();
+    }
+
+    const suppressions = [...suppressedAreaWayLayerMasks].sort(([a], [b]) => a - b);
+
+    return new ShortbreadFeatureIndex(
+      sharedFloat64(bboxes),
+      sharedUint32(records.map((record) => record.entityIndex)),
+      sharedUint8(records.map((record) => record.entityType)),
+      sharedUint8(records.map((record) => record.geometryMask)),
+      sharedUint32(records.map((record) => record.layerMask)),
+      spatialIndex,
+      sharedFloat64(suppressions.map(([id]) => id)),
+      sharedUint32(suppressions.map(([, mask]) => mask)),
+    );
+  }
+
+  static fromTransferables(
+    transferables: ShortbreadFeatureIndexTransferables,
+  ): ShortbreadFeatureIndex {
+    const suppressedAreaWayIds = new Float64Array(transferables.suppressedAreaWayIds);
+    const suppressedAreaWayLayerMasks = transferables.suppressedAreaWayLayerMasks
+      ? new Uint32Array(transferables.suppressedAreaWayLayerMasks)
+      : new Uint32Array(suppressedAreaWayIds.length).fill(0xffff_ffff);
+
+    return new ShortbreadFeatureIndex(
+      new Float64Array(transferables.bboxes),
+      new Uint32Array(transferables.entityIndexes),
+      new Uint8Array(transferables.entityTypes),
+      new Uint8Array(transferables.geometryMasks),
+      new Uint32Array(transferables.layerMasks),
+      transferables.spatialIndex ? Flatbush.from(transferables.spatialIndex) : null,
+      suppressedAreaWayIds,
+      suppressedAreaWayLayerMasks,
+    );
+  }
+
+  query(bbox: GeoBbox2D): ShortbreadFeatureRecord[];
+  query(query: ShortbreadFeatureQuery): ShortbreadFeatureRecord[];
+  query(bboxOrQuery: GeoBbox2D | ShortbreadFeatureQuery): ShortbreadFeatureRecord[] {
+    if (!this.spatialIndex) return [];
+    const query: ShortbreadFeatureQuery = Array.isArray(bboxOrQuery)
+      ? { bbox: bboxOrQuery as GeoBbox2D }
+      : bboxOrQuery;
+    const entityTypes = query.entityTypes?.map(encodedEntityType);
+    const requestedLayerMask = queryLayerMask(query.layers);
+    const positions = this.spatialIndex
+      .search(...query.bbox, (position) => {
+        if (entityTypes && !entityTypes.includes(this.entityTypes[position] as EncodedEntityType)) {
+          return false;
+        }
+        if (
+          query.geometryMask !== undefined &&
+          (this.geometryMasks[position]! & query.geometryMask) === 0
+        ) {
+          return false;
+        }
+        return (
+          requestedLayerMask === undefined ||
+          (this.layerMasks[position]! & requestedLayerMask) !== 0
+        );
+      })
+      .sort((a, b) => a - b);
+    return positions.map((position) => this.record(position));
+  }
+
+  /** Query one entity kind without materializing records rejected by the caller's filter. */
+  queryEntityIndexes(
+    bbox: GeoBbox2D,
+    entityType: ShortbreadFeatureEntityType,
+    include: (entityIndex: number) => boolean = () => true,
+  ): number[] {
+    if (!this.spatialIndex) return [];
+    const encodedType = encodedEntityType(entityType);
+    return this.spatialIndex
+      .search(...bbox, (position) => {
+        const entityIndex = this.entityIndexes[position]!;
+        return this.entityTypes[position] === encodedType && include(entityIndex);
+      })
+      .sort((a, b) => a - b)
+      .map((position) => this.entityIndexes[position]!);
+  }
+
+  /** Return the Shortbread layers supplied by classified area relations for this member way. */
+  suppressedLayerMaskForWay(id: number): number {
+    let low = 0;
+    let high = this.suppressedAreaWayIds.length - 1;
+    while (low <= high) {
+      const middle = (low + high) >>> 1;
+      const candidate = this.suppressedAreaWayIds[middle]!;
+      if (candidate === id) return this.suppressedAreaWayLayerMasks[middle] ?? 0;
+      if (candidate < id) low = middle + 1;
+      else high = middle - 1;
+    }
+    return 0;
+  }
+
+  /** Test whether a relation supplies all or one specific classified layer for a member way. */
+  suppressesWay(id: number, layer?: ShortbreadLayerName): boolean {
+    const mask = this.suppressedLayerMaskForWay(id);
+    if (layer === undefined) return mask !== 0;
+    const bit = layerBits.get(layer);
+    return bit !== undefined && (mask & bit) !== 0;
+  }
+
+  transferables(): ShortbreadFeatureIndexTransferables {
+    return {
+      bboxes: this.bboxes.buffer,
+      entityIndexes: this.entityIndexes.buffer,
+      entityTypes: this.entityTypes.buffer,
+      geometryMasks: this.geometryMasks.buffer,
+      layerMasks: this.layerMasks.buffer,
+      ...(this.spatialIndex ? { spatialIndex: this.spatialIndex.data as BufferType } : {}),
+      suppressedAreaWayIds: this.suppressedAreaWayIds.buffer,
+      suppressedAreaWayLayerMasks: this.suppressedAreaWayLayerMasks.buffer,
+    };
+  }
+
+  backingBuffers(): BufferType[] {
+    return getShortbreadFeatureIndexBuffers(this.transferables());
+  }
+
+  private record(position: number): ShortbreadFeatureRecord {
+    const offset = position * 4;
+    return {
+      entityIndex: this.entityIndexes[position]!,
+      entityType: entityTypeName(this.entityTypes[position]! as EncodedEntityType),
+      geometryMask: this.geometryMasks[position]!,
+      layerMask: this.layerMasks[position]!,
+      bbox: [
+        this.bboxes[offset]!,
+        this.bboxes[offset + 1]!,
+        this.bboxes[offset + 2]!,
+        this.bboxes[offset + 3]!,
+      ],
+    };
+  }
+}
+
+/** Test whether a compact feature record was classified into a layer. */
+export function shortbreadFeatureHasLayer(
+  record: Pick<ShortbreadFeatureRecord, "layerMask">,
+  layer: ShortbreadLayerName,
+): boolean {
+  const bit = layerBits.get(layer);
+  return bit !== undefined && (record.layerMask & bit) !== 0;
+}

--- a/packages/shortbread/src/index.ts
+++ b/packages/shortbread/src/index.ts
@@ -9,10 +9,11 @@
  * import { ShortbreadVtEncoder } from "@osmix/shortbread"
  *
  * const encoder = new ShortbreadVtEncoder(osm)
- * const tile = encoder.getTile([z, x, y])
+ * const tile = encoder.getTile([x, y, z])
  * ```
  */
 
-export { ShortbreadVtEncoder } from "./encoder.ts";
+export { ShortbreadVtEncoder, type ShortbreadVtEncoderOptions } from "./encoder.ts";
+export * from "./feature-index.ts";
 export { getLayersForGeometryType, matchTags, SHORTBREAD_LAYERS } from "./layers.ts";
 export type * from "./types.ts";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -734,6 +734,9 @@ importers:
       '@osmix/vt':
         specifier: workspace:*
         version: link:../vt
+      flatbush:
+        specifier: ^4.6.2
+        version: 4.6.2
     devDependencies:
       '@mapbox/tilebelt':
         specifier: ^2.0.3
@@ -741,9 +744,15 @@ importers:
       '@mapbox/vector-tile':
         specifier: ^3.0.0
         version: 3.0.0
+      '@osmix/load':
+        specifier: workspace:*
+        version: link:../load
       '@osmix/shared':
         specifier: workspace:*
         version: link:../shared
+      '@osmix/test-utils':
+        specifier: workspace:*
+        version: link:../test-utils
       pbf:
         specifier: 'catalog:'
         version: 5.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -232,6 +232,9 @@ importers:
       '@osmix/core':
         specifier: workspace:*
         version: link:../../packages/core
+      '@osmix/shared':
+        specifier: workspace:*
+        version: link:../../packages/shared
       '@osmix/shortbread':
         specifier: workspace:*
         version: link:../../packages/shortbread
@@ -257,9 +260,9 @@ importers:
       '@osmix/pbf':
         specifier: workspace:*
         version: link:../../packages/pbf
-      '@osmix/shared':
-        specifier: workspace:*
-        version: link:../../packages/shared
+      tsx:
+        specifier: ^4.23.0
+        version: 4.23.0
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
@@ -4934,7 +4937,6 @@ snapshots:
       '@esbuild/win32-arm64': 0.28.1
       '@esbuild/win32-ia32': 0.28.1
       '@esbuild/win32-x64': 0.28.1
-    optional: true
 
   esprima@4.0.1: {}
 
@@ -5773,7 +5775,6 @@ snapshots:
       esbuild: 0.28.1
     optionalDependencies:
       fsevents: 2.3.3
-    optional: true
 
   tw-animate-css@1.4.0: {}
 

--- a/scripts/node-smoke.ts
+++ b/scripts/node-smoke.ts
@@ -19,9 +19,14 @@ interface WorkspacePackage {
 
 const repoRoot = resolve(import.meta.dirname, "..");
 const packagesRoot = join(repoRoot, "packages");
-const smokeDependencies = ["@osmix/core", "osmix"] as const;
+const smokeDependencies = ["@osmix/core", "@osmix/shared", "@osmix/shortbread", "osmix"] as const;
 const consumerSource = `import { Osm } from "@osmix/core"
-import { createRemote, fromPbf } from "osmix"
+import { inspectBackingBuffers } from "@osmix/shared/backing-buffers"
+import { runCooperatively } from "@osmix/shared/cooperative"
+import { GenerationGate } from "@osmix/shared/generation-gate"
+import { ShortbreadFeatureIndex, ShortbreadVtEncoder } from "@osmix/shortbread"
+import { createRemote, fromPbf, getOsmixCapabilities, getWorkerRuntime } from "osmix"
+import { createOsmixWorkerPool } from "osmix/worker-pool"
 
 function assert(condition, message) {
   if (!condition) throw new Error(message)
@@ -32,14 +37,23 @@ assert(osm.id === "smoke", "@osmix/core import failed")
 assert(typeof fromPbf === "function", "fromPbf import failed")
 assert(typeof createRemote === "function", "createRemote import failed")
 
-const remote = await createRemote({ inProcess: true })
+const workerRuntime = getWorkerRuntime()
+const capabilities = getOsmixCapabilities()
+assert(
+  workerRuntime === "node" || workerRuntime === "bun" || workerRuntime === "deno",
+  "unexpected worker runtime: " + workerRuntime,
+)
+assert(capabilities.workerRuntime === workerRuntime, "capability runtime mismatch")
+assert(capabilities.canShareArrayBuffers, workerRuntime + " cannot share array buffers")
+
+const remote = await createRemote({ workerCount: 2 })
 try {
   const geojson = {
     type: "FeatureCollection",
     features: [{
       type: "Feature",
       geometry: { type: "Point", coordinates: [7.4229, 43.7371] },
-      properties: { name: "Runtime smoke" },
+      properties: { amenity: "cafe", name: "Runtime smoke" },
     }],
   }
   const data = new TextEncoder().encode(JSON.stringify(geojson))
@@ -47,11 +61,114 @@ try {
   assert(dataset.stats.nodes === 1, "GeoJSON point was not loaded")
   assert(dataset.stats.ways === 0, "GeoJSON point unexpectedly created a way")
   assert((await dataset.toPbfData()).byteLength > 0, "PBF serialization was empty")
+
+  const localOsm = await dataset.get()
+  const featureIndex = ShortbreadFeatureIndex.build(localOsm)
+  const candidates = featureIndex.query({
+    bbox: localOsm.bbox(),
+    entityTypes: ["node"],
+    layers: ["pois"],
+  })
+  assert(candidates.length === 1, "Shortbread feature-index query failed")
+  assert(
+    inspectBackingBuffers(featureIndex.transferables()).unique > 0,
+    "shared backing-buffer inspection failed",
+  )
+  const encoded = new ShortbreadVtEncoder(localOsm, { featureIndex }).getTileForBbox(
+    localOsm.bbox(),
+    () => [2048, 2048],
+  )
+  assert(encoded.byteLength > 0, "indexed Shortbread encoding was empty")
 } finally {
-  remote[Symbol.dispose]()
+  await remote.dispose()
 }
 
-console.log("Osmix runtime smoke test passed")
+const generation = GenerationGate.create({ shared: false })
+generation.update(4)
+assert(generation.isCancelled(3), "generation gate failed")
+const cooperative = await runCooperatively((function* () {
+  yield
+  return "cooperative-ok"
+})())
+assert(
+  cooperative.status === "completed" && cooperative.value === "cooperative-ok",
+  "cooperative scheduler failed",
+)
+
+if (workerRuntime !== "none") {
+  const custom = await createRemote({
+    workerCount: 1,
+    workerUrl: new URL("./custom.worker.mjs", import.meta.url),
+  })
+  try {
+    const result = await custom.runWithWorker((worker) => worker.runtimeSmokePing(), {
+      retry: "once",
+    })
+    assert(result === "custom-worker-ok", "custom " + workerRuntime + " worker entry failed")
+
+    let timerFired = false
+    const timer = setTimeout(() => {
+      timerFired = true
+    }, 5)
+    await custom.runWithWorker((worker) => worker.runtimeSmokeBlock(50))
+    clearTimeout(timer)
+    assert(timerFired, workerRuntime + " worker blocked the caller event loop")
+  } finally {
+    await custom.dispose()
+  }
+
+  const pool = await createOsmixWorkerPool({
+    workerCount: 2,
+    workerUrl: new URL("./custom.worker.mjs", import.meta.url),
+  })
+  try {
+    const result = await pool.run((worker) => worker.runtimeSmokePing(), { retry: "once" })
+    assert(result === "custom-worker-ok", "worker-pool subpath failed")
+
+    const shared = new SharedArrayBuffer(4)
+    const local = new Uint8Array(shared)
+    await pool.broadcast((worker) => worker.runtimeSmokeInstallSharedBuffer(shared))
+    await pool.runOn(0, (worker) => worker.runtimeSmokeWriteSharedByte(0, 41))
+    const remoteByte = await pool.runOn(1, (worker) => worker.runtimeSmokeReadSharedByte(0))
+    assert(remoteByte === 41 && local[0] === 41, workerRuntime + " did not share one buffer")
+  } finally {
+    await pool.dispose()
+  }
+}
+
+console.log("Osmix " + workerRuntime + " worker smoke test passed")
+`;
+
+const customWorkerSource = `import { exposeOsmixWorker, OsmixWorker } from "osmix"
+
+class RuntimeSmokeWorker extends OsmixWorker {
+  shared
+
+  runtimeSmokePing() {
+    return "custom-worker-ok"
+  }
+
+  runtimeSmokeBlock(milliseconds) {
+    const end = performance.now() + milliseconds
+    while (performance.now() < end) {}
+    return true
+  }
+
+  runtimeSmokeInstallSharedBuffer(buffer) {
+    this.shared = new Uint8Array(buffer)
+    return buffer instanceof SharedArrayBuffer
+  }
+
+  runtimeSmokeWriteSharedByte(index, value) {
+    this.shared[index] = value
+  }
+
+  runtimeSmokeReadSharedByte(index) {
+    return this.shared?.[index]
+  }
+}
+
+await exposeOsmixWorker(new RuntimeSmokeWorker())
 `;
 
 type Runtime = "bun" | "deno" | "node";
@@ -62,13 +179,14 @@ function getRuntime(): Runtime {
   throw Error(`Unsupported smoke runtime: ${runtime}`);
 }
 
-function npmEnv(): NodeJS.ProcessEnv {
+function npmEnv(cacheDir?: string): NodeJS.ProcessEnv {
   const env = { ...process.env };
   for (const key of Object.keys(env)) {
     if (key.startsWith("npm_config_")) {
       delete env[key];
     }
   }
+  if (cacheDir) env["npm_config_cache"] = cacheDir;
   return env;
 }
 
@@ -76,13 +194,13 @@ function run(
   command: string,
   args: string[],
   cwd: string,
-  options: { captureOutput?: boolean; cleanNpmEnv?: boolean } = {},
+  options: { captureOutput?: boolean; cleanNpmEnv?: boolean; npmCacheDir?: string } = {},
 ): string {
-  const { captureOutput = false, cleanNpmEnv = false } = options;
+  const { captureOutput = false, cleanNpmEnv = false, npmCacheDir } = options;
   const result = spawnSync(command, args, {
     cwd,
     encoding: "utf8",
-    env: cleanNpmEnv ? npmEnv() : process.env,
+    env: cleanNpmEnv ? npmEnv(npmCacheDir) : process.env,
     stdio: captureOutput ? ["ignore", "pipe", "inherit"] : "inherit",
   });
 
@@ -229,6 +347,7 @@ async function writeConsumerApp(
   await mkdir(consumerDir, { recursive: true });
 
   await writeFile(join(consumerDir, "index.mjs"), consumerSource);
+  await writeFile(join(consumerDir, "custom.worker.mjs"), customWorkerSource);
   await writeFile(
     join(consumerDir, "package.json"),
     JSON.stringify(
@@ -270,6 +389,7 @@ async function main(): Promise<void> {
     console.log("Installing local tarballs into npm consumer app...");
     run("npm", ["install", "--no-fund", "--no-audit"], consumerDir, {
       cleanNpmEnv: true,
+      npmCacheDir: join(tempRoot, "npm-cache"),
     });
 
     console.log(`Running ${runtime} import and data smoke test...`);
@@ -280,7 +400,7 @@ async function main(): Promise<void> {
         runtime === "node" ? (process.env["OSMIX_NODE_BINARY"] ?? runtime) : runtime;
       run(executable, ["./index.mjs"], consumerDir);
     }
-    if (runtime === "node") console.log("Node/npm smoke test passed");
+    console.log(`${runtime}/npm smoke test passed`);
   } finally {
     await rm(tempRoot, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

- add cooperative scheduling, generation cancellation, and backing-buffer diagnostics to `@osmix/shared`
- add transferable Shortbread feature indexes and indexed encoding
- add the cross-runtime managed Osmix worker pool for browsers, Node, Bun, and Deno
- migrate Merge and the Shortbread server to managed worker scheduling
- extend raster drawing with configurable point radii and variable-width lines

## Why

The terminal viewer work introduced concurrency and indexing capabilities that are useful beyond the CLI. This PR establishes those reusable APIs and consumer migrations independently, keeping OpenTUI-specific rendering out of the shared packages.

## Release impact

- minor: `@osmix/shared`, `@osmix/shortbread`, `@osmix/raster`, `osmix`
- patch: `@osmix/core` and its affected internal dependents
- no application changesets

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm run verify:all`
- `pnpm --filter @osmix/merge test:e2e` - 8 passed
- `pnpm run check:deps`
- `pnpm exec changeset status --since=origin/main`
- published-package Node worker smoke passed
