### PR TITLE
Add the Osmix terminal CLI

### DIFF
--- a/.changeset/small-cli-explores.md
+++ b/.changeset/small-cli-explores.md
@@ -1,0 +1,5 @@
+---
+"@osmix/cli": patch
+---
+
+Add the interactive `osmix` terminal map viewer and standalone release executables.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,31 @@ jobs:
         uses: actions/checkout@v7
 
       - uses: ./.github/actions/setup
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
       - uses: ./.github/actions/checks
+
+  cli-executable:
+    name: CLI standalone executable
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - uses: ./.github/actions/setup
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Build and test the standalone executable
+        run: pnpm --filter @osmix/cli run test:executable
 
   runtime-node:
     name: Runtime smoke (Node ${{ matrix.node }})

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,3 +36,27 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.CHANGESETS_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
           NPM_TOKEN: "" # Workaround to support trusted publishing
+
+      - name: Setup Bun for standalone executables
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Check CLI release assets
+        id: cli-assets
+        run: bun packages/cli/scripts/release-executables.ts >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Build CLI release executables
+        if: steps.cli-assets.outputs.needed == 'true'
+        run: pnpm --filter @osmix/cli run build:executables
+
+      - name: Upload CLI release executables
+        if: steps.cli-assets.outputs.needed == 'true'
+        run: |
+          gh release upload "${{ steps.cli-assets.outputs.tag }}" \
+            packages/cli/dist/executables/release/* \
+            --clobber
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ See each package's README for full API and description.
 | [`@osmix/shapefile`](packages/shapefile/README.md)   | Shapefile import.                                                                      |
 | [`@osmix/change`](packages/change/README.md)         | Deduplication, merging, and changeset workflows.                                       |
 | [`@osmix/raster`](packages/raster/README.md)         | Render OSM entities as raster bitmaps.                                                 |
+| [`@osmix/cli`](packages/cli/README.md)               | Explore OSM PBF files in an interactive terminal map.                                  |
 | [`@osmix/vt`](packages/vt/README.md)                 | Encode OSM entities as Mapbox Vector Tiles (MVT).                                      |
 | [`@osmix/shortbread`](packages/shortbread/README.md) | Shortbread schema vector tiles.                                                        |
 | [`@osmix/shared`](packages/shared/README.md)         | Utility functions and geometry helpers.                                                |

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,101 @@
+# @osmix/cli
+
+`@osmix/cli` provides the `osmix` command for exploring a local OSM PBF file in an interactive terminal map. It parses and indexes the file with the `osmix` facade, renders styled XYZ raster tiles, and displays them through an OpenTUI framebuffer.
+
+## Installation
+
+### Standalone executable
+
+Each [`@osmix/cli` GitHub Release](https://github.com/conveyal/osmix/releases) includes standalone
+executables for macOS, Linux, and Windows on x64 and arm64. Linux downloads are available for both
+glibc and musl. These downloads include Bun and OpenTUI, so no separate runtime is required.
+
+On macOS or Linux, download the archive for your platform and extract it:
+
+```sh
+tar -xzf osmix-vVERSION-macos-arm64.tar.gz
+chmod +x osmix
+./osmix monaco.pbf
+```
+
+Windows downloads are `.zip` archives containing `osmix.exe`. Release downloads are currently
+unsigned, so macOS Gatekeeper or Windows SmartScreen may ask for confirmation. Verify downloads
+against the release's `SHA256SUMS` file. Minimal Alpine installations may also need `libstdc++` and
+`libgcc`.
+
+### Bun package
+
+The native OpenTUI renderer requires [Bun](https://bun.sh/).
+
+```sh
+bun add --global @osmix/cli
+```
+
+## Usage
+
+```sh
+osmix monaco.pbf
+```
+
+The viewer opens immediately and reports parsing progress in its status bar. PBF streaming, semantic indexing, label queries, and missing map tiles stay in Web Workers so the spinner and controls remain responsive throughout loading. One logical core remains available for OpenTUI and input. The shared Osmix worker runtime supplies availability scheduling, timeouts, retry-once recovery, and diagnostics; the CLI adds a control lane for labels and compute lanes for tiles. Runtimes without shared buffers use one worker without copying the dataset onto the main thread.
+
+The main thread retains only dataset metadata and prepared pixels. Labels arrive asynchronously for the latest camera revision, and stale results are discarded after a pan, zoom, or resize. Pending tiles use a sparse diagonal shimmer drawn during OpenTUI post-processing, while cached portions remain unchanged. Tile work is dispatched independently of successful terminal frames, so output backpressure cannot stall the queue. Shared-buffer workers cancel stale tiles through the common atomic generation gate; the single-worker fallback yields between rendering chunks so an out-of-band cancellation notification can run without moving work onto the main thread. A failed worker is restarted and rehydrated once; the viewer reports a repeated failure instead of falling back to blocking local parsing or rendering.
+
+The built-in dark basemap classifies OSM features with the Shortbread schema. Water, land use, buildings, boundaries, transportation, and selected points use distinct, high-contrast colors and a stable layer order. Road colors and widths follow their highway class, with tunnels below surface streets and bridges above them. Overview zooms show major roads from zoom 7, secondary roads from zoom 8, tertiary and residential streets from zoom 9, and service streets from zoom 10. These additional overview streets use thin uncased strokes until their normal detail zoom. Buildings appear from zoom 13, while paths and point symbols appear from zoom 14.
+
+The control worker builds one transferable Shortbread feature index for classification and spatial
+queries. Tile workers share those backing buffers, while small CLI-owned overlays add zoom
+visibility and label metadata without duplicating the dataset or building separate spatial indexes.
+
+Named places, roads, water, parks, sites, and selected points of interest appear progressively as the map zooms in. Labels use local OSM names when available, stay horizontal for terminal readability, and are laid out across the whole viewport to avoid collisions and tile-boundary duplicates. Subtle dark backplates keep text readable without changing the raster tile cache.
+
+### Controls
+
+| Input                  | Action                  |
+| ---------------------- | ----------------------- |
+| Arrows or `h j k l`    | Pan                     |
+| `+` / `-`              | Zoom one level          |
+| Mouse drag             | Pan                     |
+| Mouse wheel            | Zoom around the pointer |
+| `0`                    | Fit the dataset         |
+| `q`, Escape, or Ctrl+C | Quit                    |
+
+The terminal can be resized while the viewer is open. Horizontal panning wraps around the antimeridian; vertical panning is limited to the Web Mercator world bounds.
+
+## Programmatic usage
+
+```ts
+import { openPbfViewer } from "@osmix/cli";
+
+await openPbfViewer("monaco.pbf");
+```
+
+`openPbfViewer` requires an interactive terminal and resolves after the viewer closes.
+
+## Development
+
+From the repository root:
+
+```sh
+pnpm --filter @osmix/cli run start -- fixtures/monaco.pbf
+pnpm --filter @osmix/cli run build:executable
+pnpm --filter @osmix/cli run run:executable -- fixtures/monaco.pbf
+pnpm --filter @osmix/cli run test:executable
+pnpm run verify:workspace -- @osmix/cli
+```
+
+The executable smoke test compiles both the CLI and its worker into one host binary, checks help and
+version output, and launches Monaco in a PTY before quitting cleanly. Release CI builds the complete
+eight-target matrix and attaches archives plus `SHA256SUMS` to the matching `@osmix/cli` release.
+
+To exercise the regional-file responsiveness and memory harness with a larger local PBF:
+
+```sh
+OSMIX_CLI_STRESS_PBF=/path/to/region.osm.pbf pnpm --filter @osmix/cli run stress:regional
+```
+
+The opt-in harness renders fitted and close-zoom views followed by six rapid pan revisions. Its
+JSON report includes per-revision tile and label latency, cancellation counts, animation heartbeat
+gaps, main-loop stalls, RSS, worker count, and the shared-buffer/restart telemetry observable through
+the renderer interface. It fails when a heartbeat or main-loop stall exceeds 250 ms. Set
+`OSMIX_CLI_STRESS_TIMEOUT_MS` to raise or lower the default ten-minute timeout for each stage.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json.schemastore.org/package.json",
+  "name": "@osmix/cli",
+  "version": "0.0.1",
+  "description": "Explore OSM PBF files in a terminal map viewer",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/conveyal/osmix.git"
+  },
+  "bin": {
+    "osmix": "./src/cli.ts"
+  },
+  "type": "module",
+  "main": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "build:executable": "bun scripts/build-executables.ts --host",
+    "build:executables": "bun scripts/prepare-executable-dependencies.ts && bun scripts/build-executables.ts --all",
+    "run:executable": "bun scripts/run-executable.ts",
+    "start": "bun src/cli.ts",
+    "stress:regional": "bun test/regional-stress.ts",
+    "test": "pnpm -w exec vitest run --project \"$npm_package_name\"",
+    "test:executable": "bun scripts/test-executable.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@opentui/core": "^0.4.3",
+    "@osmix/geo": "workspace:*",
+    "@osmix/shared": "workspace:*",
+    "@osmix/shortbread": "workspace:*",
+    "comlink": "^4.4.2",
+    "osmix": "workspace:*"
+  },
+  "devDependencies": {
+    "@osmix/test-utils": "workspace:*",
+    "typescript": "catalog:"
+  }
+}

--- a/packages/cli/scripts/build-executables.ts
+++ b/packages/cli/scripts/build-executables.ts
@@ -1,0 +1,252 @@
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { chmod, mkdir, readFile, rename, rm, stat, symlink, writeFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+
+import packageJson from "../package.json" with { type: "json" };
+import {
+  executableRoot,
+  executableDependencyRoot,
+  executableTargets,
+  hostExecutablePath,
+  releaseArchiveName,
+  releaseExecutableDirectory,
+  targetDefines,
+  type BunExecutableTarget,
+  type ExecutableTarget,
+} from "./executable-targets.ts";
+
+interface BunBuildOptions {
+  compile:
+    | { autoloadBunfig: false; autoloadDotenv: false; outfile: string }
+    | {
+        autoloadBunfig: false;
+        autoloadDotenv: false;
+        outfile: string;
+        target: BunExecutableTarget;
+      };
+  define: Record<string, string>;
+  entrypoints: string[];
+  minify: boolean;
+}
+
+interface BunBuildResult {
+  logs: unknown[];
+  success: boolean;
+}
+
+interface BunRuntime {
+  build(options: BunBuildOptions): Promise<BunBuildResult>;
+}
+
+const entrypoints = [
+  resolve(import.meta.dirname, "../src/cli.ts"),
+  resolve(import.meta.dirname, "../src/cli.worker.ts"),
+];
+
+function bunRuntime(): BunRuntime {
+  const bun = (globalThis as unknown as { Bun?: BunRuntime }).Bun;
+  if (!bun) throw Error("Standalone executable builds must run with Bun.");
+  return bun;
+}
+
+function hostDefines(): Record<string, string> {
+  const define: Record<string, string> = {
+    "process.env.NODE_ENV": JSON.stringify("production"),
+  };
+  if (process.platform !== "linux") return define;
+  const report = process.report?.getReport() as {
+    header?: { glibcVersionRuntime?: string };
+  };
+  define["process.env.OPENTUI_LIBC"] = JSON.stringify(
+    report.header?.glibcVersionRuntime ? "glibc" : "musl",
+  );
+  return define;
+}
+
+async function compile(
+  outfile: string,
+  define: Record<string, string>,
+  target?: BunExecutableTarget,
+): Promise<void> {
+  await mkdir(dirname(outfile), { recursive: true });
+  const compileOptions = target
+    ? { autoloadBunfig: false as const, autoloadDotenv: false as const, outfile, target }
+    : { autoloadBunfig: false as const, autoloadDotenv: false as const, outfile };
+  const result = await bunRuntime().build({
+    compile: compileOptions,
+    define,
+    entrypoints,
+    minify: true,
+  });
+  if (!result.success) {
+    throw Error(`Bun executable build failed:\n${result.logs.map(String).join("\n")}`);
+  }
+}
+
+function run(command: string, args: string[]): void {
+  const result = spawnSync(command, args, { encoding: "utf8" });
+  if (result.status === 0) return;
+  throw Error(
+    `${command} ${args.join(" ")} failed: ${result.stderr || result.stdout || result.error}`,
+  );
+}
+
+async function assertNativePackages(): Promise<void> {
+  const missing: string[] = [];
+  for (const { nativePackage } of executableTargets) {
+    try {
+      await stat(resolve(executableDependencyRoot, "node_modules", nativePackage));
+    } catch {
+      missing.push(nativePackage);
+    }
+  }
+  if (missing.length === 0) return;
+
+  const corePackagePath = resolve(
+    import.meta.dirname,
+    "../node_modules/@opentui/core/package.json",
+  );
+  const corePackage = JSON.parse(await readFile(corePackagePath, "utf8")) as { version: string };
+  throw Error(
+    `Missing OpenTUI native packages: ${missing.join(", ")}\n` +
+      "Prepare them before cross-compiling:\n" +
+      `bun scripts/prepare-executable-dependencies.ts # OpenTUI ${corePackage.version}`,
+  );
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function withStagedOpenTui<T>(runBuild: () => Promise<T>): Promise<T> {
+  const packageRoot = resolve(import.meta.dirname, "..");
+  const opentuiScope = resolve(packageRoot, "node_modules/@opentui");
+  const backupScope = resolve(packageRoot, "node_modules/@opentui-osmix-executable-backup");
+  const stagedScope = resolve(executableDependencyRoot, "node_modules/@opentui");
+
+  if (await pathExists(backupScope)) {
+    await rm(opentuiScope, { force: true, recursive: true });
+    await rename(backupScope, opentuiScope);
+  }
+  await rename(opentuiScope, backupScope);
+  await symlink(stagedScope, opentuiScope, "dir");
+  try {
+    return await runBuild();
+  } finally {
+    await rm(opentuiScope, { force: true, recursive: true });
+    await rename(backupScope, opentuiScope);
+  }
+}
+
+async function archiveTarget(target: ExecutableTarget, executablePath: string): Promise<string> {
+  const archivePath = join(
+    releaseExecutableDirectory,
+    releaseArchiveName(packageJson.version, target),
+  );
+  if (target.archive === "zip") {
+    run("zip", ["-q", "-j", archivePath, executablePath]);
+  } else {
+    run("tar", ["-czf", archivePath, "-C", dirname(executablePath), target.executableName]);
+  }
+  const entries = spawnSync(
+    target.archive === "zip" ? "unzip" : "tar",
+    target.archive === "zip" ? ["-Z1", archivePath] : ["-tzf", archivePath],
+    { encoding: "utf8" },
+  );
+  const names = entries.stdout?.trim().split("\n").filter(Boolean) ?? [];
+  if (entries.status !== 0 || names.length !== 1 || names[0] !== target.executableName) {
+    throw Error(`Unexpected contents in ${archivePath}: ${names.join(", ")}`);
+  }
+  return archivePath;
+}
+
+async function validateExecutable(target: ExecutableTarget, executablePath: string): Promise<void> {
+  const bytes = await readFile(executablePath);
+  if (target.id.startsWith("macos-")) {
+    const cpu = bytes.readUInt32LE(4);
+    const expectedCpu = target.id.endsWith("arm64") ? 0x0100000c : 0x01000007;
+    if (bytes.readUInt32LE(0) !== 0xfeedfacf || cpu !== expectedCpu) {
+      throw Error(`Unexpected Mach-O architecture for ${target.id}`);
+    }
+    return;
+  }
+  if (target.id.startsWith("linux-")) {
+    const machine = bytes.readUInt16LE(18);
+    const expectedMachine = target.id.includes("arm64") ? 183 : 62;
+    const interpreter = target.libc === "musl" ? "/lib/ld-musl-" : "ld-linux";
+    if (
+      !bytes.subarray(0, 4).equals(Buffer.from([0x7f, 0x45, 0x4c, 0x46])) ||
+      machine !== expectedMachine ||
+      !bytes.includes(interpreter)
+    ) {
+      throw Error(`Unexpected ELF architecture or libc for ${target.id}`);
+    }
+    return;
+  }
+  const peOffset = bytes.readUInt32LE(0x3c);
+  const machine = bytes.readUInt16LE(peOffset + 4);
+  const expectedMachine = target.id.endsWith("arm64") ? 0xaa64 : 0x8664;
+  if (bytes.subarray(0, 2).toString() !== "MZ" || machine !== expectedMachine) {
+    throw Error(`Unexpected PE architecture for ${target.id}`);
+  }
+}
+
+async function writeChecksums(paths: string[]): Promise<void> {
+  const lines: string[] = [];
+  for (const path of paths) {
+    const digest = createHash("sha256")
+      .update(await readFile(path))
+      .digest("hex");
+    lines.push(`${digest}  ${path.slice(path.lastIndexOf("/") + 1)}`);
+  }
+  await writeFile(join(releaseExecutableDirectory, "SHA256SUMS"), `${lines.join("\n")}\n`);
+}
+
+export async function buildHostExecutable(): Promise<string> {
+  await rm(join(executableRoot, "host"), { force: true, recursive: true });
+  await compile(hostExecutablePath, hostDefines());
+  if (process.platform !== "win32") await chmod(hostExecutablePath, 0o755);
+  return hostExecutablePath;
+}
+
+export async function buildReleaseExecutables(): Promise<string[]> {
+  await assertNativePackages();
+  return withStagedOpenTui(async () => {
+    await rm(executableRoot, { force: true, recursive: true });
+    await mkdir(releaseExecutableDirectory, { recursive: true });
+
+    const archives: string[] = [];
+    for (const target of executableTargets) {
+      const executablePath = join(executableRoot, "stage", target.id, target.executableName);
+      process.stdout.write(`Building ${target.id}…\n`);
+      await compile(executablePath, targetDefines(target), target.bunTarget);
+      if (target.executableName === "osmix") await chmod(executablePath, 0o755);
+      await validateExecutable(target, executablePath);
+      archives.push(await archiveTarget(target, executablePath));
+    }
+    await writeChecksums(archives);
+    return archives;
+  });
+}
+
+async function main(): Promise<void> {
+  const mode = process.argv[2];
+  if (mode === "--host") {
+    process.stdout.write(`${await buildHostExecutable()}\n`);
+    return;
+  }
+  if (mode === "--all") {
+    await buildReleaseExecutables();
+    process.stdout.write(`${releaseExecutableDirectory}\n`);
+    return;
+  }
+  throw Error("Usage: bun scripts/build-executables.ts --host|--all");
+}
+
+if (import.meta.main) await main();

--- a/packages/cli/scripts/executable-targets.ts
+++ b/packages/cli/scripts/executable-targets.ts
@@ -1,0 +1,123 @@
+import { join } from "node:path";
+
+export type ExecutableTargetId =
+  | "macos-arm64"
+  | "macos-x64"
+  | "linux-arm64-glibc"
+  | "linux-x64-glibc"
+  | "linux-arm64-musl"
+  | "linux-x64-musl"
+  | "windows-arm64"
+  | "windows-x64";
+
+export type BunExecutableTarget =
+  | "bun-darwin-arm64"
+  | "bun-darwin-x64-baseline"
+  | "bun-linux-arm64"
+  | "bun-linux-x64-baseline"
+  | "bun-linux-arm64-musl"
+  | "bun-linux-x64-musl"
+  | "bun-windows-arm64"
+  | "bun-windows-x64-baseline";
+
+export interface ExecutableTarget {
+  archive: "tar.gz" | "zip";
+  bunTarget: BunExecutableTarget;
+  executableName: "osmix" | "osmix.exe";
+  id: ExecutableTargetId;
+  libc?: "glibc" | "musl";
+  nativePackage: string;
+}
+
+export const executableTargets: readonly ExecutableTarget[] = [
+  {
+    archive: "tar.gz",
+    bunTarget: "bun-darwin-arm64",
+    executableName: "osmix",
+    id: "macos-arm64",
+    nativePackage: "@opentui/core-darwin-arm64",
+  },
+  {
+    archive: "tar.gz",
+    bunTarget: "bun-darwin-x64-baseline",
+    executableName: "osmix",
+    id: "macos-x64",
+    nativePackage: "@opentui/core-darwin-x64",
+  },
+  {
+    archive: "tar.gz",
+    bunTarget: "bun-linux-arm64",
+    executableName: "osmix",
+    id: "linux-arm64-glibc",
+    libc: "glibc",
+    nativePackage: "@opentui/core-linux-arm64",
+  },
+  {
+    archive: "tar.gz",
+    bunTarget: "bun-linux-x64-baseline",
+    executableName: "osmix",
+    id: "linux-x64-glibc",
+    libc: "glibc",
+    nativePackage: "@opentui/core-linux-x64",
+  },
+  {
+    archive: "tar.gz",
+    bunTarget: "bun-linux-arm64-musl",
+    executableName: "osmix",
+    id: "linux-arm64-musl",
+    libc: "musl",
+    nativePackage: "@opentui/core-linux-arm64-musl",
+  },
+  {
+    archive: "tar.gz",
+    bunTarget: "bun-linux-x64-musl",
+    executableName: "osmix",
+    id: "linux-x64-musl",
+    libc: "musl",
+    nativePackage: "@opentui/core-linux-x64-musl",
+  },
+  {
+    archive: "zip",
+    bunTarget: "bun-windows-arm64",
+    executableName: "osmix.exe",
+    id: "windows-arm64",
+    nativePackage: "@opentui/core-win32-arm64",
+  },
+  {
+    archive: "zip",
+    bunTarget: "bun-windows-x64-baseline",
+    executableName: "osmix.exe",
+    id: "windows-x64",
+    nativePackage: "@opentui/core-win32-x64",
+  },
+];
+
+export const executableRoot = join(import.meta.dirname, "../dist/executables");
+export const executableDependencyRoot = join(import.meta.dirname, "../dist/executable-native-deps");
+export const hostExecutableName = process.platform === "win32" ? "osmix.exe" : "osmix";
+export const hostExecutablePath = join(executableRoot, "host", hostExecutableName);
+export const releaseExecutableDirectory = join(executableRoot, "release");
+
+export function releaseArchiveName(version: string, target: ExecutableTarget): string {
+  return `osmix-v${version}-${target.id}.${target.archive}`;
+}
+
+export function expectedReleaseAssetNames(version: string): string[] {
+  return [...executableTargets.map((target) => releaseArchiveName(version, target)), "SHA256SUMS"];
+}
+
+export function missingReleaseAssetNames(
+  version: string,
+  existingNames: Iterable<string>,
+): string[] {
+  const existing = new Set(existingNames);
+  return expectedReleaseAssetNames(version).filter((name) => !existing.has(name));
+}
+
+export function targetDefines(target: ExecutableTarget): Record<string, string> {
+  const define: Record<string, string> = {
+    "process.env.NODE_ENV": JSON.stringify("production"),
+  };
+  if (target.libc) define["process.env.OPENTUI_LIBC"] = JSON.stringify(target.libc);
+  return define;
+}

--- a/packages/cli/scripts/prepare-executable-dependencies.ts
+++ b/packages/cli/scripts/prepare-executable-dependencies.ts
@@ -1,0 +1,25 @@
+import { spawnSync } from "node:child_process";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+
+import { executableDependencyRoot } from "./executable-targets.ts";
+
+const packageRoot = resolve(import.meta.dirname, "..");
+const corePackagePath = resolve(packageRoot, "node_modules/@opentui/core/package.json");
+const corePackage = JSON.parse(await readFile(corePackagePath, "utf8")) as { version: string };
+
+await rm(executableDependencyRoot, { force: true, recursive: true });
+await mkdir(executableDependencyRoot, { recursive: true });
+await writeFile(
+  resolve(executableDependencyRoot, "package.json"),
+  `${JSON.stringify({ private: true }, null, "\t")}\n`,
+);
+
+const install = spawnSync(
+  process.execPath,
+  ["install", "--no-save", "--os=*", "--cpu=*", `@opentui/core@${corePackage.version}`],
+  { cwd: executableDependencyRoot, stdio: "inherit" },
+);
+if (install.status !== 0) throw Error("Unable to prepare OpenTUI native packages.");
+
+process.stdout.write(`Prepared OpenTUI ${corePackage.version} native packages.\n`);

--- a/packages/cli/scripts/release-executables.ts
+++ b/packages/cli/scripts/release-executables.ts
@@ -1,0 +1,28 @@
+import { spawnSync } from "node:child_process";
+
+import packageJson from "../package.json" with { type: "json" };
+import { missingReleaseAssetNames } from "./executable-targets.ts";
+
+function capture(command: string, args: string[]): string | null {
+  const result = spawnSync(command, args, { encoding: "utf8" });
+  return result.status === 0 ? result.stdout.trim() : null;
+}
+
+const tag = `@osmix/cli@${packageJson.version}`;
+const releaseAssets = capture("gh", [
+  "release",
+  "view",
+  tag,
+  "--json",
+  "assets",
+  "--jq",
+  ".assets[].name",
+]);
+const existing = new Set(releaseAssets?.split("\n").filter(Boolean) ?? []);
+const missing = missingReleaseAssetNames(packageJson.version, existing);
+const needed = releaseAssets !== null && missing.length > 0;
+
+process.stdout.write(`needed=${needed}\n`);
+process.stdout.write(`tag=${tag}\n`);
+process.stdout.write(`version=${packageJson.version}\n`);
+process.stdout.write(`missing=${missing.join(",")}\n`);

--- a/packages/cli/scripts/run-executable.ts
+++ b/packages/cli/scripts/run-executable.ts
@@ -1,0 +1,8 @@
+import { spawnSync } from "node:child_process";
+
+import { buildHostExecutable } from "./build-executables.ts";
+
+const executable = await buildHostExecutable();
+const result = spawnSync(executable, process.argv.slice(2), { stdio: "inherit" });
+if (result.error) throw result.error;
+process.exitCode = result.status ?? 1;

--- a/packages/cli/scripts/test-executable.ts
+++ b/packages/cli/scripts/test-executable.ts
@@ -1,0 +1,125 @@
+import { spawn, spawnSync } from "node:child_process";
+import { resolve } from "node:path";
+
+import packageJson from "../package.json" with { type: "json" };
+import { buildHostExecutable } from "./build-executables.ts";
+
+function assertCommand(executable: string, args: string[], expected: string): void {
+  const result = spawnSync(executable, args, { encoding: "utf8" });
+  if (result.status !== 0 || !result.stdout.includes(expected)) {
+    throw Error(`${executable} ${args.join(" ")} failed:\n${result.stdout}\n${result.stderr}`);
+  }
+}
+
+function quoteShell(value: string): string {
+  return `'${value.replaceAll("'", `'\\''`)}'`;
+}
+
+function runDarwinPtySmoke(executable: string, fixture: string): void {
+  const expectScript = String.raw`
+set timeout 60
+set executable $env(OSMIX_EXECUTABLE)
+set fixture $env(OSMIX_FIXTURE)
+spawn -noecho $executable $fixture
+expect {
+  -re {Error:} {
+    send -- "q"
+    expect eof
+    exit 1
+  }
+  -re {z[0-9]+.*nodes} {
+    after 1000
+    send -- "q"
+  }
+  timeout {
+    send -- "q"
+    exit 1
+  }
+}
+expect eof
+catch wait result
+exit [lindex $result 3]
+`;
+  const result = spawnSync("expect", ["-c", expectScript], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      COLUMNS: "80",
+      LINES: "24",
+      OSMIX_EXECUTABLE: executable,
+      OSMIX_FIXTURE: fixture,
+      TERM: "xterm-256color",
+    },
+    maxBuffer: 4 * 1024 * 1024,
+    timeout: 65_000,
+  });
+  const output = `${result.stdout}${result.stderr}`;
+  if (result.status !== 0 || output.includes("ModuleNotFound")) {
+    throw Error(`Standalone viewer PTY smoke failed:\n${output.slice(-4_000)}`);
+  }
+}
+
+async function runPtySmoke(executable: string): Promise<void> {
+  if (process.platform === "win32") {
+    process.stdout.write(
+      "Skipping automated PTY smoke on Windows; run:executable remains available.\n",
+    );
+    return;
+  }
+
+  const fixture = resolve(import.meta.dirname, "../../../fixtures/monaco.pbf");
+  if (process.platform === "darwin") {
+    runDarwinPtySmoke(executable, fixture);
+    return;
+  }
+
+  const shellCommand = `stty cols 80 rows 24; exec ${quoteShell(executable)} ${quoteShell(fixture)}`;
+  const scriptArgs = ["-qefc", shellCommand, "/dev/null"];
+
+  await new Promise<void>((resolvePromise, reject) => {
+    const child = spawn("script", scriptArgs, {
+      env: { ...process.env, COLUMNS: "80", LINES: "24", TERM: "xterm-256color" },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let output = "";
+    let rendered = false;
+    let quitSent = false;
+    const timeout = setTimeout(() => {
+      child.kill("SIGTERM");
+      reject(Error(`Timed out waiting for standalone viewer:\n${output.slice(-4_000)}`));
+    }, 60_000);
+
+    const record = (chunk: Buffer) => {
+      output = `${output}${chunk.toString()}`.slice(-2_000_000);
+      if (!quitSent && output.includes("Error:")) {
+        quitSent = true;
+        child.stdin.write("q");
+      }
+      if (!quitSent && output.includes("nodes") && /z\d{1,2}/.test(output)) {
+        rendered = true;
+        quitSent = true;
+        child.stdin.write("q");
+      }
+    };
+    child.stdout.on("data", record);
+    child.stderr.on("data", record);
+    child.once("error", (error) => {
+      clearTimeout(timeout);
+      reject(error);
+    });
+    child.once("close", (code) => {
+      clearTimeout(timeout);
+      if (!rendered || code !== 0 || output.includes("ModuleNotFound")) {
+        reject(Error(`Standalone viewer smoke failed with exit ${code}:\n${output.slice(-4_000)}`));
+        return;
+      }
+      resolvePromise();
+    });
+  });
+}
+
+const executable = await buildHostExecutable();
+assertCommand(executable, ["--help"], "Usage: osmix <file.osm.pbf>");
+assertCommand(executable, ["--version"], `osmix ${packageJson.version}`);
+await runPtySmoke(executable);
+process.stdout.write(`Standalone executable smoke passed: ${executable}\n`);

--- a/packages/cli/src/args.ts
+++ b/packages/cli/src/args.ts
@@ -1,0 +1,35 @@
+export const USAGE = `Usage: osmix <file.osm.pbf>
+
+Open an OSM PBF file in an interactive terminal map viewer.
+
+Controls:
+  arrows / h j k l  Pan
+  + / -              Zoom in or out
+  mouse drag         Pan
+  mouse wheel        Zoom in or out
+  0                  Fit the dataset
+  q / escape         Quit`;
+
+export class CliUsageError extends Error {
+  constructor(message: string) {
+    super(`${message}\n\n${USAGE}`);
+    this.name = "CliUsageError";
+  }
+}
+
+export type CliArgs = { kind: "help" } | { kind: "version" } | { kind: "view"; filePath: string };
+
+/** Parse the single positional PBF path accepted by the CLI. */
+export function parseCliArgs(args: string[]): CliArgs {
+  if (args.length === 1 && (args[0] === "--help" || args[0] === "-h")) {
+    return { kind: "help" };
+  }
+  if (args.length === 1 && (args[0] === "--version" || args[0] === "-V")) {
+    return { kind: "version" };
+  }
+  if (args.length === 0) throw new CliUsageError("Missing OSM PBF file path.");
+  if (args.length > 1) throw new CliUsageError("Expected exactly one OSM PBF file path.");
+  const filePath = args[0]!;
+  if (filePath.startsWith("-")) throw new CliUsageError(`Unknown option: ${filePath}`);
+  return { kind: "view", filePath };
+}

--- a/packages/cli/src/camera.ts
+++ b/packages/cli/src/camera.ts
@@ -1,0 +1,147 @@
+import type { GeoBbox2D, LonLat } from "osmix";
+
+export const TILE_SIZE = 256;
+export const MIN_ZOOM = 0;
+export const MAX_ZOOM = 20;
+
+const MAX_MERCATOR_LATITUDE = 85.051_128_78;
+const FIT_PADDING = 0.9;
+
+export interface MapViewport {
+  width: number;
+  height: number;
+}
+
+export interface ScreenPoint {
+  x: number;
+  y: number;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+function wrap(value: number): number {
+  return ((value % 1) + 1) % 1;
+}
+
+function worldXToLon(x: number): number {
+  return x * 360 - 180;
+}
+
+export function lonLatToWorld([lon, lat]: LonLat): ScreenPoint {
+  const limitedLat = clamp(lat, -MAX_MERCATOR_LATITUDE, MAX_MERCATOR_LATITUDE);
+  const radians = (limitedLat * Math.PI) / 180;
+  return {
+    x: wrap((lon + 180) / 360),
+    y: clamp((1 - Math.log(Math.tan(radians) + 1 / Math.cos(radians)) / Math.PI) / 2, 0, 1),
+  };
+}
+
+export function worldToLonLat({ x, y }: ScreenPoint): LonLat {
+  const lon = wrap(x) * 360 - 180;
+  const lat = (Math.atan(Math.sinh(Math.PI * (1 - 2 * clamp(y, 0, 1)))) * 180) / Math.PI;
+  return [lon, lat];
+}
+
+/** Integer-zoom Web Mercator camera for a terminal-sized pixel viewport. */
+export class MapCamera {
+  centerX: number;
+  centerY: number;
+  zoom: number;
+
+  constructor(centerX = 0.5, centerY = 0.5, zoom = MIN_ZOOM) {
+    this.centerX = wrap(centerX);
+    this.centerY = clamp(centerY, 0, 1);
+    this.zoom = clamp(Math.round(zoom), MIN_ZOOM, MAX_ZOOM);
+  }
+
+  static fitBounds(bounds: GeoBbox2D, viewport: MapViewport): MapCamera {
+    const northwest = lonLatToWorld([bounds[0], bounds[3]]);
+    const southeast = lonLatToWorld([bounds[2], bounds[1]]);
+    const width = Math.max(0, southeast.x - northwest.x);
+    const height = Math.max(0, southeast.y - northwest.y);
+    const availableWidth = Math.max(1, viewport.width) * FIT_PADDING;
+    const availableHeight = Math.max(1, viewport.height) * FIT_PADDING;
+    const xScale = width === 0 ? Number.POSITIVE_INFINITY : availableWidth / (width * TILE_SIZE);
+    const yScale = height === 0 ? Number.POSITIVE_INFINITY : availableHeight / (height * TILE_SIZE);
+    const scale = Math.min(xScale, yScale);
+    const zoom = Number.isFinite(scale)
+      ? clamp(Math.floor(Math.log2(scale)), MIN_ZOOM, MAX_ZOOM)
+      : MAX_ZOOM;
+    return new MapCamera(
+      wrap(northwest.x + width / 2),
+      clamp(northwest.y + height / 2, 0, 1),
+      zoom,
+    );
+  }
+
+  get center(): LonLat {
+    return worldToLonLat({ x: this.centerX, y: this.centerY });
+  }
+
+  get worldSize(): number {
+    return TILE_SIZE * 2 ** this.zoom;
+  }
+
+  origin(viewport: MapViewport): ScreenPoint {
+    return {
+      x: Math.round(this.centerX * this.worldSize - viewport.width / 2),
+      y: Math.round(this.centerY * this.worldSize - viewport.height / 2),
+    };
+  }
+
+  /** Project a coordinate into viewport pixels, choosing the nearest wrapped world copy. */
+  project(coordinate: LonLat, viewport: MapViewport): ScreenPoint {
+    const world = lonLatToWorld(coordinate);
+    const origin = this.origin(viewport);
+    const viewportCenterX = origin.x + viewport.width / 2;
+    const unwrappedX = world.x * this.worldSize;
+    const nearestX =
+      unwrappedX + Math.round((viewportCenterX - unwrappedX) / this.worldSize) * this.worldSize;
+    return {
+      x: nearestX - origin.x,
+      y: world.y * this.worldSize - origin.y,
+    };
+  }
+
+  /** Return one or two geographic bboxes covering the viewport across the antimeridian. */
+  visibleBboxes(viewport: MapViewport): GeoBbox2D[] {
+    const origin = this.origin(viewport);
+    const northY = clamp(origin.y / this.worldSize, 0, 1);
+    const southY = clamp((origin.y + viewport.height) / this.worldSize, 0, 1);
+    const north = worldToLonLat({ x: 0, y: northY })[1];
+    const south = worldToLonLat({ x: 0, y: southY })[1];
+    if (viewport.width >= this.worldSize) return [[-180, south, 180, north]];
+
+    const west = origin.x / this.worldSize;
+    const east = (origin.x + viewport.width) / this.worldSize;
+    const westWorld = wrap(west);
+    const span = east - west;
+    const eastWorld = westWorld + span;
+    if (eastWorld <= 1) {
+      return [[worldXToLon(westWorld), south, worldXToLon(eastWorld), north]];
+    }
+    return [
+      [worldXToLon(westWorld), south, 180, north],
+      [-180, south, worldXToLon(eastWorld - 1), north],
+    ];
+  }
+
+  panPixels(deltaX: number, deltaY: number): void {
+    this.centerX = wrap(this.centerX + deltaX / this.worldSize);
+    this.centerY = clamp(this.centerY + deltaY / this.worldSize, 0, 1);
+  }
+
+  zoomBy(delta: number, viewport: MapViewport, anchor?: ScreenPoint): void {
+    const nextZoom = clamp(this.zoom + Math.sign(delta), MIN_ZOOM, MAX_ZOOM);
+    if (nextZoom === this.zoom) return;
+    const point = anchor ?? { x: viewport.width / 2, y: viewport.height / 2 };
+    const oldOrigin = this.origin(viewport);
+    const anchoredX = (oldOrigin.x + point.x) / this.worldSize;
+    const anchoredY = (oldOrigin.y + point.y) / this.worldSize;
+    this.zoom = nextZoom;
+    this.centerX = wrap(anchoredX + (viewport.width / 2 - point.x) / this.worldSize);
+    this.centerY = clamp(anchoredY + (viewport.height / 2 - point.y) / this.worldSize, 0, 1);
+  }
+}

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,0 +1,42 @@
+#!/usr/bin/env bun
+
+import { stat } from "node:fs/promises";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import packageJson from "../package.json" with { type: "json" };
+import { parseCliArgs, USAGE } from "./args.ts";
+import { openPbfViewer } from "./viewer.ts";
+
+async function validateFile(filePath: string): Promise<string> {
+  const absolutePath = resolve(filePath);
+  let fileStats;
+  try {
+    fileStats = await stat(absolutePath);
+  } catch {
+    throw Error(`File not found: ${filePath}`);
+  }
+  if (!fileStats.isFile()) throw Error(`Not a file: ${filePath}`);
+  return absolutePath;
+}
+
+/** Run the osmix terminal viewer CLI. */
+export async function main(args = process.argv.slice(2)): Promise<void> {
+  const parsed = parseCliArgs(args);
+  if (parsed.kind === "help") {
+    process.stdout.write(`${USAGE}\n`);
+    return;
+  }
+  if (parsed.kind === "version") {
+    process.stdout.write(`osmix ${packageJson.version}\n`);
+    return;
+  }
+  await openPbfViewer(await validateFile(parsed.filePath));
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await main().catch((error: unknown) => {
+    process.stderr.write(`osmix: ${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/packages/cli/src/cli.worker.ts
+++ b/packages/cli/src/cli.worker.ts
@@ -1,0 +1,10 @@
+import { expose } from "comlink";
+
+import { CliTileWorker } from "./tile-worker.ts";
+
+// Index builders use console timers for development diagnostics. Worker output bypasses
+// OpenTUI's console capture and would otherwise write directly into the alternate screen.
+console.time = () => undefined;
+console.timeEnd = () => undefined;
+
+expose(new CliTileWorker());

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,0 +1,1 @@
+export { openPbfViewer } from "./viewer.ts";

--- a/packages/cli/src/map-labels.ts
+++ b/packages/cli/src/map-labels.ts
@@ -1,0 +1,553 @@
+import { clipPolyline } from "@osmix/geo/lineclip";
+import { wayIsArea } from "@osmix/geo/way-is-area";
+import {
+  matchTags,
+  type PlaceKind,
+  type ShortbreadGeometryType,
+  type ShortbreadLayerName,
+  type ShortbreadProperties,
+  type StreetKind,
+  type WaterKind,
+  type WaterLineKind,
+} from "@osmix/shortbread";
+import type { GeoBbox2D, LonLat, Osm, OsmTags } from "osmix";
+
+import { MapCamera, type MapViewport, type ScreenPoint } from "./camera.ts";
+import { semanticPointCategory } from "./map-style.ts";
+
+export type MapLabelKind = "place" | "poi" | "road" | "site" | "water";
+
+type LabelPlacement = "center" | "point";
+
+export interface MapLabelMetadata {
+  kind: MapLabelKind;
+  placement: LabelPlacement;
+  priority: number;
+  text: string;
+}
+
+/** Worker-side classification retained by the semantic label index. */
+export interface IndexedMapLabelMetadata extends MapLabelMetadata {
+  minZoom: number;
+}
+
+export interface MapLabelCandidate extends MapLabelMetadata {
+  anchor: ScreenPoint;
+  stableKey: string;
+  visibleLength: number;
+}
+
+export interface MeasuredLabelText {
+  text: string;
+  width: number;
+}
+
+export interface PlacedMapLabel extends MeasuredLabelText {
+  backplateWidth: number;
+  backplateX: number;
+  kind: MapLabelKind;
+  x: number;
+  y: number;
+}
+
+export type LabelTextMeasurer = (text: string, maxWidth: number) => MeasuredLabelText | null;
+
+interface LabelRule {
+  kind: MapLabelKind;
+  minZoom: number;
+  placement: LabelPlacement;
+  priority: number;
+}
+
+interface AnchoredGeometry {
+  anchor: ScreenPoint;
+  visibleLength: number;
+}
+
+/** A preclassified semantic node supplied by the worker-owned point index. */
+export interface IndexedMapLabelNode {
+  coordinate: LonLat;
+  id: number;
+  metadata: IndexedMapLabelMetadata;
+}
+
+export interface MapLabelSpatialIndexProvider {
+  intersects(bbox: GeoBbox2D): Iterable<number>;
+}
+
+export interface CollectMapLabelCandidateOptions {
+  nodes?: Iterable<IndexedMapLabelNode>;
+  relations?: MapLabelSpatialIndexProvider;
+  ways?: MapLabelSpatialIndexProvider;
+}
+
+interface CollisionBox {
+  bottom: number;
+  left: number;
+  right: number;
+  top: number;
+}
+
+const MAX_LABEL_WIDTH = 24;
+const GRAPHEME_SEGMENTER = new Intl.Segmenter(undefined, { granularity: "grapheme" });
+
+function normalizedText(value: string | undefined): string | null {
+  const text = value?.trim().replace(/\s+/g, " ");
+  return text ? text : null;
+}
+
+/** Truncate text using OpenTUI-provided terminal widths for each grapheme. */
+export function truncateLabelText(
+  text: string,
+  graphemeWidths: number[],
+  maxWidth: number,
+): MeasuredLabelText | null {
+  const width = graphemeWidths.reduce((total, graphemeWidth) => total + graphemeWidth, 0);
+  if (width <= maxWidth) return width > 0 ? { text, width } : null;
+
+  const graphemes = [...GRAPHEME_SEGMENTER.segment(text)].map((segment) => segment.segment);
+  const contentWidth = Math.max(0, maxWidth - 1);
+  let truncated = "";
+  let truncatedWidth = 0;
+  for (const [index, graphemeWidth] of graphemeWidths.entries()) {
+    if (truncatedWidth + graphemeWidth > contentWidth) break;
+    truncated += graphemes[index] ?? "";
+    truncatedWidth += graphemeWidth;
+  }
+  return truncated ? { text: `${truncated}…`, width: truncatedWidth + 1 } : null;
+}
+
+function labelText(properties: ShortbreadProperties, allowRef: boolean): string | null {
+  return (
+    normalizedText(properties.name) ??
+    normalizedText(properties.name_en) ??
+    (allowRef && "ref" in properties ? normalizedText(properties.ref) : null)
+  );
+}
+
+function placeMinZoom(kind: PlaceKind): number {
+  if (["continent", "country", "state", "city"].includes(kind)) return 4;
+  if (kind === "town") return 7;
+  if (kind === "village") return 9;
+  if (kind === "suburb") return 10;
+  if (kind === "hamlet" || kind === "neighbourhood") return 12;
+  return 13;
+}
+
+function placePriority(kind: PlaceKind): number {
+  if (kind === "continent" || kind === "country") return 1_050;
+  if (kind === "state" || kind === "city") return 1_040;
+  if (kind === "town") return 1_030;
+  if (kind === "village") return 1_020;
+  if (kind === "suburb") return 1_010;
+  return 1_000;
+}
+
+function roadRule(kind: StreetKind): LabelRule | null {
+  if (["motorway", "motorway_link", "trunk", "trunk_link"].includes(kind)) {
+    return { kind: "road", minZoom: 9, placement: "center", priority: 940 };
+  }
+  if (kind === "primary" || kind === "primary_link") {
+    return { kind: "road", minZoom: 9, placement: "center", priority: 930 };
+  }
+  if (kind === "secondary" || kind === "secondary_link") {
+    return { kind: "road", minZoom: 10, placement: "center", priority: 920 };
+  }
+  if (kind === "tertiary" || kind === "tertiary_link") {
+    return { kind: "road", minZoom: 11, placement: "center", priority: 840 };
+  }
+  if (kind === "residential" || kind === "unclassified") {
+    return { kind: "road", minZoom: 12, placement: "center", priority: 830 };
+  }
+  if (kind === "service" || kind === "living_street" || kind === "pedestrian") {
+    return { kind: "road", minZoom: 14, placement: "center", priority: 820 };
+  }
+  if (["track", "footway", "path", "cycleway", "steps", "bridleway"].includes(kind)) {
+    return { kind: "road", minZoom: 15, placement: "center", priority: 810 };
+  }
+  return null;
+}
+
+function waterAreaRule(kind: WaterKind): LabelRule {
+  const minor = kind === "dock" || kind === "swimming_pool";
+  return { kind: "water", minZoom: minor ? 13 : 8, placement: "center", priority: 880 };
+}
+
+function waterLineRule(kind: WaterLineKind): LabelRule {
+  const major = kind === "river" || kind === "canal";
+  return { kind: "water", minZoom: major ? 10 : 13, placement: "center", priority: 870 };
+}
+
+function ruleForMatch(
+  layer: ShortbreadLayerName,
+  properties: ShortbreadProperties,
+): LabelRule | null {
+  switch (layer) {
+    case "places": {
+      const kind = properties.kind as PlaceKind;
+      return {
+        kind: "place",
+        minZoom: placeMinZoom(kind),
+        placement: "center",
+        priority: placePriority(kind),
+      };
+    }
+    case "street_labels":
+      return roadRule(properties.kind as StreetKind);
+    case "water":
+      return waterAreaRule(properties.kind as WaterKind);
+    case "water_lines_labels":
+      return waterLineRule(properties.kind as WaterLineKind);
+    case "sites":
+      return { kind: "site", minZoom: 12, placement: "center", priority: 700 };
+    case "pois": {
+      const category = semanticPointCategory(properties.kind);
+      if (!category) return null;
+      return {
+        kind: "poi",
+        minZoom: category === "food" ? 15 : 14,
+        placement: "point",
+        priority: 600,
+      };
+    }
+    default:
+      return null;
+  }
+}
+
+/** Resolve one preferred label classification for tagged geometry at a zoom level. */
+export function resolveLabelMetadata(
+  tags: OsmTags,
+  geometryType: ShortbreadGeometryType,
+  zoom: number,
+): MapLabelMetadata | null {
+  const indexed = resolveIndexedLabelMetadata(tags, geometryType, zoom);
+  if (!indexed) return null;
+  const { minZoom: _minZoom, ...metadata } = indexed;
+  return metadata;
+}
+
+/** Resolve label metadata while retaining its minimum zoom for worker-side indexing. */
+export function resolveIndexedLabelMetadata(
+  tags: OsmTags,
+  geometryType: ShortbreadGeometryType,
+  zoom = Number.POSITIVE_INFINITY,
+): IndexedMapLabelMetadata | null {
+  let best: IndexedMapLabelMetadata | null = null;
+  for (const match of matchTags(tags, geometryType)) {
+    const rule = ruleForMatch(match.layer.name, match.properties);
+    if (!rule || zoom < rule.minZoom) continue;
+    const text = labelText(match.properties, rule.kind === "road");
+    if (!text) continue;
+    const metadata = {
+      kind: rule.kind,
+      minZoom: rule.minZoom,
+      placement: rule.placement,
+      priority: rule.priority,
+      text,
+    };
+    if (!best || metadata.priority > best.priority) best = metadata;
+  }
+  return best;
+}
+
+function visibleIndexes(
+  bboxes: GeoBbox2D[],
+  search: (bbox: GeoBbox2D) => Iterable<number>,
+): number[] {
+  const indexes = new Set<number>();
+  for (const bbox of bboxes) {
+    for (const index of search(bbox)) indexes.add(index);
+  }
+  return [...indexes];
+}
+
+function lineLength(points: ScreenPoint[]): number {
+  let length = 0;
+  for (let index = 1; index < points.length; index++) {
+    const previous = points[index - 1]!;
+    const point = points[index]!;
+    length += Math.hypot(point.x - previous.x, point.y - previous.y);
+  }
+  return length;
+}
+
+function lineMidpoint(points: ScreenPoint[], totalLength: number): ScreenPoint {
+  let remaining = totalLength / 2;
+  for (let index = 1; index < points.length; index++) {
+    const previous = points[index - 1]!;
+    const point = points[index]!;
+    const segmentLength = Math.hypot(point.x - previous.x, point.y - previous.y);
+    if (remaining <= segmentLength) {
+      const fraction = segmentLength === 0 ? 0 : remaining / segmentLength;
+      return {
+        x: previous.x + (point.x - previous.x) * fraction,
+        y: previous.y + (point.y - previous.y) * fraction,
+      };
+    }
+    remaining -= segmentLength;
+  }
+  return points.at(-1)!;
+}
+
+function visibleLineAnchor(
+  lineStrings: LonLat[][],
+  camera: MapCamera,
+  viewport: MapViewport,
+): AnchoredGeometry | null {
+  let best: AnchoredGeometry | null = null;
+  const clipBbox: [number, number, number, number] = [0, 0, viewport.width, viewport.height];
+  for (const lineString of lineStrings) {
+    const projected = lineString.map((coordinate) => camera.project(coordinate, viewport));
+    const clipped = clipPolyline(
+      projected.map((point) => [point.x, point.y]),
+      clipBbox,
+    );
+    for (const segment of clipped) {
+      const points = segment.map(([x, y]) => ({ x, y }));
+      const visibleLength = lineLength(points);
+      if (points.length < 2 || visibleLength === 0) continue;
+      if (!best || visibleLength > best.visibleLength) {
+        best = { anchor: lineMidpoint(points, visibleLength), visibleLength };
+      }
+    }
+  }
+  return best;
+}
+
+function polygonAnchor(
+  polygons: LonLat[][][],
+  camera: MapCamera,
+  viewport: MapViewport,
+): AnchoredGeometry | null {
+  let best: AnchoredGeometry | null = null;
+  for (const polygon of polygons) {
+    const outerRing = polygon[0];
+    if (!outerRing || outerRing.length === 0) continue;
+    const points = outerRing.map((coordinate) => camera.project(coordinate, viewport));
+    const xs = points.map((point) => point.x);
+    const ys = points.map((point) => point.y);
+    const minX = Math.min(...xs);
+    const maxX = Math.max(...xs);
+    const minY = Math.min(...ys);
+    const maxY = Math.max(...ys);
+    const area = (maxX - minX) * (maxY - minY);
+    if (!best || area > best.visibleLength) {
+      best = {
+        anchor: { x: (minX + maxX) / 2, y: (minY + maxY) / 2 },
+        visibleLength: area,
+      };
+    }
+  }
+  return best;
+}
+
+function addCandidate(
+  candidates: MapLabelCandidate[],
+  metadata: MapLabelMetadata | null,
+  geometry: AnchoredGeometry | null,
+  stableKey: string,
+): boolean {
+  if (!metadata || !geometry) return false;
+  candidates.push({ ...metadata, ...geometry, stableKey });
+  return true;
+}
+
+function preferredCandidate(
+  current: MapLabelCandidate,
+  candidate: MapLabelCandidate,
+): MapLabelCandidate {
+  if (candidate.priority !== current.priority) {
+    return candidate.priority > current.priority ? candidate : current;
+  }
+  if (candidate.visibleLength !== current.visibleLength) {
+    return candidate.visibleLength > current.visibleLength ? candidate : current;
+  }
+  return candidate.stableKey < current.stableKey ? candidate : current;
+}
+
+function deduplicateLineLabels(candidates: MapLabelCandidate[]): MapLabelCandidate[] {
+  const result: MapLabelCandidate[] = [];
+  const lines = new Map<string, MapLabelCandidate>();
+  for (const candidate of candidates) {
+    if (candidate.kind !== "road" && candidate.kind !== "water") {
+      result.push(candidate);
+      continue;
+    }
+    const key = `${candidate.kind}:${candidate.text.toLocaleLowerCase()}`;
+    const current = lines.get(key);
+    lines.set(key, current ? preferredCandidate(current, candidate) : candidate);
+  }
+  result.push(...lines.values());
+  return result;
+}
+
+/** Collect semantic label candidates for the current viewport. */
+export function collectMapLabelCandidates(
+  osm: Osm,
+  camera: MapCamera,
+  viewport: MapViewport,
+  options: CollectMapLabelCandidateOptions = {},
+): MapLabelCandidate[] {
+  const bboxes = camera.visibleBboxes(viewport);
+  const candidates: MapLabelCandidate[] = [];
+  const suppressedAreaWayIds = new Set<number>();
+
+  const relationIndex = options.relations ?? osm.relations;
+  for (const index of visibleIndexes(bboxes, (bbox) => relationIndex.intersects(bbox))) {
+    const relation = osm.relations.getByIndex(index);
+    if (!relation?.tags) continue;
+    const polygonMetadata = resolveLabelMetadata(relation.tags, "Polygon", camera.zoom);
+    const lineMetadata = resolveLabelMetadata(relation.tags, "LineString", camera.zoom);
+    const pointMetadata = resolveLabelMetadata(relation.tags, "Point", camera.zoom);
+    if (!polygonMetadata && !lineMetadata && !pointMetadata) continue;
+    const geometry = osm.relations.getRelationGeometry(index);
+    if (geometry.rings && polygonMetadata) {
+      const added = addCandidate(
+        candidates,
+        polygonMetadata,
+        polygonAnchor(geometry.rings, camera, viewport),
+        `relation:${relation.id}:polygon`,
+      );
+      if (added) {
+        for (const member of relation.members) {
+          if (member.type === "way") suppressedAreaWayIds.add(member.ref);
+        }
+      }
+    }
+    if (geometry.lineStrings && lineMetadata) {
+      addCandidate(
+        candidates,
+        lineMetadata,
+        visibleLineAnchor(geometry.lineStrings, camera, viewport),
+        `relation:${relation.id}:line`,
+      );
+    }
+    if (geometry.points && pointMetadata) {
+      for (const [pointIndex, point] of geometry.points.entries()) {
+        addCandidate(
+          candidates,
+          pointMetadata,
+          { anchor: camera.project(point, viewport), visibleLength: 0 },
+          `relation:${relation.id}:point:${pointIndex}`,
+        );
+      }
+    }
+  }
+
+  const wayIndex = options.ways ?? osm.ways;
+  for (const index of visibleIndexes(bboxes, (bbox) => wayIndex.intersects(bbox))) {
+    const way = osm.ways.getByIndex(index);
+    if (!way?.tags) continue;
+    const isArea = wayIsArea(way);
+    if (isArea && suppressedAreaWayIds.has(way.id)) continue;
+    const metadata = resolveLabelMetadata(way.tags, isArea ? "Polygon" : "LineString", camera.zoom);
+    if (!metadata) continue;
+    const coordinates = osm.ways.getCoordinates(index);
+    if (isArea) {
+      addCandidate(
+        candidates,
+        metadata,
+        polygonAnchor([[coordinates]], camera, viewport),
+        `way:${way.id}:polygon`,
+      );
+    } else {
+      addCandidate(
+        candidates,
+        metadata,
+        visibleLineAnchor([coordinates], camera, viewport),
+        `way:${way.id}:line`,
+      );
+    }
+  }
+
+  if (options.nodes) {
+    for (const node of options.nodes) {
+      if (camera.zoom < node.metadata.minZoom) continue;
+      const { minZoom: _minZoom, ...metadata } = node.metadata;
+      addCandidate(
+        candidates,
+        metadata,
+        { anchor: camera.project(node.coordinate, viewport), visibleLength: 0 },
+        `node:${node.id}:point`,
+      );
+    }
+  } else {
+    for (const index of visibleIndexes(bboxes, (bbox) => osm.nodes.findIndexesWithinBbox(bbox))) {
+      const tags = osm.nodes.tags.getTags(index);
+      if (!tags) continue;
+      const id = osm.nodes.ids.at(index);
+      addCandidate(
+        candidates,
+        resolveLabelMetadata(tags, "Point", camera.zoom),
+        {
+          anchor: camera.project(osm.nodes.getNodeLonLat({ index }), viewport),
+          visibleLength: 0,
+        },
+        `node:${id}:point`,
+      );
+    }
+  }
+
+  return deduplicateLineLabels(candidates);
+}
+
+function overlaps(a: CollisionBox, b: CollisionBox): boolean {
+  return a.left <= b.right && a.right >= b.left && a.top <= b.bottom && a.bottom >= b.top;
+}
+
+function placementXs(candidate: MapLabelCandidate, textWidth: number): number[] {
+  const centerX = Math.round(candidate.anchor.x);
+  if (candidate.placement === "point") {
+    return [centerX + 2, centerX - textWidth - 2];
+  }
+  return [Math.round(candidate.anchor.x - textWidth / 2)];
+}
+
+/** Place measured labels into terminal cells using deterministic priority collisions. */
+export function layoutMapLabels(
+  candidates: MapLabelCandidate[],
+  viewport: MapViewport,
+  measureText: LabelTextMeasurer,
+): PlacedMapLabel[] {
+  const maxWidth = Math.min(MAX_LABEL_WIDTH, Math.max(0, viewport.width - 4));
+  if (maxWidth === 0 || viewport.height === 0) return [];
+  const acceptedBoxes: CollisionBox[] = [];
+  const placed: PlacedMapLabel[] = [];
+  const sorted = [...candidates].sort(
+    (a, b) =>
+      b.priority - a.priority ||
+      b.visibleLength - a.visibleLength ||
+      a.stableKey.localeCompare(b.stableKey),
+  );
+
+  for (const candidate of sorted) {
+    const measured = measureText(candidate.text, maxWidth);
+    if (!measured || measured.width <= 0) continue;
+    const y = Math.floor(candidate.anchor.y / 2);
+    if (y < 0 || y >= viewport.height) continue;
+    for (const x of placementXs(candidate, measured.width)) {
+      const backplateX = x - 1;
+      const backplateWidth = measured.width + 2;
+      if (backplateX < 0 || backplateX + backplateWidth > viewport.width) continue;
+      const collisionBox = {
+        left: backplateX - 1,
+        right: backplateX + backplateWidth,
+        top: y - 1,
+        bottom: y + 1,
+      };
+      if (acceptedBoxes.some((box) => overlaps(box, collisionBox))) continue;
+      acceptedBoxes.push(collisionBox);
+      placed.push({
+        ...measured,
+        backplateWidth,
+        backplateX,
+        kind: candidate.kind,
+        x,
+        y,
+      });
+      break;
+    }
+  }
+  return placed;
+}

--- a/packages/cli/src/map-pixels.ts
+++ b/packages/cli/src/map-pixels.ts
@@ -1,0 +1,303 @@
+import type { Tile } from "osmix";
+
+import { type MapViewport, MapCamera, TILE_SIZE } from "./camera.ts";
+
+export const MAP_BACKGROUND = [7, 17, 13] as const;
+const MAX_CACHED_TILES = 64;
+export const TILE_LOADING_BASE = MAP_BACKGROUND;
+export const TILE_LOADING_HIGHLIGHT = [26, 73, 53] as const;
+export const SHIMMER_PERIOD = 24;
+
+export interface TileImage {
+  data: Uint8ClampedArray;
+}
+
+export interface PendingTileRegion {
+  bottom: number;
+  left: number;
+  right: number;
+  top: number;
+}
+
+export type TileProvider = (tile: Tile) => TileImage | null;
+export type TileRenderer = (
+  tile: Tile,
+  generation: number,
+) => TileImage | null | Promise<TileImage | null>;
+
+export function formatTileLoadingStatus(pendingCount: number, spinner: string): string {
+  return `${spinner} Rendering ${pendingCount} ${pendingCount === 1 ? "tile" : "tiles"}…`;
+}
+
+interface PendingTile {
+  generation: number;
+  tile: Tile;
+}
+
+interface OsmTileLoaderOptions {
+  maxCachedTiles?: number;
+  maxConcurrentTiles?: number;
+  onError?: (error: unknown) => void;
+  onGenerationChange?: (generation: number) => void;
+  onPendingChange?: (pendingCount: number) => void;
+  onTileComplete?: () => void;
+  renderTile: TileRenderer;
+}
+
+function modulo(value: number, divisor: number): number {
+  return ((value % divisor) + divisor) % divisor;
+}
+
+function fillBackground(pixels: Uint8ClampedArray): void {
+  for (let offset = 0; offset < pixels.length; offset += 4) {
+    pixels[offset] = MAP_BACKGROUND[0];
+    pixels[offset + 1] = MAP_BACKGROUND[1];
+    pixels[offset + 2] = MAP_BACKGROUND[2];
+    pixels[offset + 3] = 255;
+  }
+}
+
+function fillLoadingPixel(pixels: Uint8ClampedArray, offset: number): void {
+  pixels[offset] = TILE_LOADING_BASE[0];
+  pixels[offset + 1] = TILE_LOADING_BASE[1];
+  pixels[offset + 2] = TILE_LOADING_BASE[2];
+  pixels[offset + 3] = 255;
+}
+
+/** Return whether a terminal cell is the sparse highlight for this animation phase. */
+export function isShimmerCell(x: number, y: number, phase: number): boolean {
+  return modulo(x + y * 2 - phase, SHIMMER_PERIOD) === 0;
+}
+
+function compositePixel(
+  target: Uint8ClampedArray,
+  targetOffset: number,
+  source: Uint8ClampedArray,
+  sourceOffset: number,
+): void {
+  const alpha = source[sourceOffset + 3]! / 255;
+  if (alpha === 0) return;
+  const inverseAlpha = 1 - alpha;
+  target[targetOffset] = Math.round(
+    source[sourceOffset]! * alpha + MAP_BACKGROUND[0] * inverseAlpha,
+  );
+  target[targetOffset + 1] = Math.round(
+    source[sourceOffset + 1]! * alpha + MAP_BACKGROUND[1] * inverseAlpha,
+  );
+  target[targetOffset + 2] = Math.round(
+    source[sourceOffset + 2]! * alpha + MAP_BACKGROUND[2] * inverseAlpha,
+  );
+}
+
+/** Compose cached XYZ raster tiles into the current terminal map viewport. */
+export function renderMapPixels(
+  camera: MapCamera,
+  viewport: MapViewport,
+  getTile: TileProvider,
+  pendingRegions?: PendingTileRegion[],
+): Uint8ClampedArray {
+  const width = Math.max(0, Math.floor(viewport.width));
+  const height = Math.max(0, Math.floor(viewport.height));
+  const pixels = new Uint8ClampedArray(width * height * 4);
+  fillBackground(pixels);
+  if (width === 0 || height === 0) return pixels;
+
+  const origin = camera.origin({ width, height });
+  const firstTileX = Math.floor(origin.x / TILE_SIZE);
+  const lastTileX = Math.floor((origin.x + width - 1) / TILE_SIZE);
+  const firstTileY = Math.floor(origin.y / TILE_SIZE);
+  const lastTileY = Math.floor((origin.y + height - 1) / TILE_SIZE);
+  const tileCount = 2 ** camera.zoom;
+
+  const visibleTiles: Array<{
+    distance: number;
+    screenLeft: number;
+    screenTop: number;
+    tile: Tile;
+  }> = [];
+  for (let worldTileY = firstTileY; worldTileY <= lastTileY; worldTileY++) {
+    if (worldTileY < 0 || worldTileY >= tileCount) continue;
+    for (let worldTileX = firstTileX; worldTileX <= lastTileX; worldTileX++) {
+      const tileX = modulo(worldTileX, tileCount);
+      const screenLeft = worldTileX * TILE_SIZE - origin.x;
+      const screenTop = worldTileY * TILE_SIZE - origin.y;
+      const centerX = screenLeft + TILE_SIZE / 2 - width / 2;
+      const centerY = screenTop + TILE_SIZE / 2 - height / 2;
+      visibleTiles.push({
+        distance: centerX * centerX + centerY * centerY,
+        screenLeft,
+        screenTop,
+        tile: [tileX, worldTileY, camera.zoom],
+      });
+    }
+  }
+  visibleTiles.sort((a, b) => a.distance - b.distance);
+
+  for (const visible of visibleTiles) {
+    const { screenLeft, screenTop } = visible;
+    const tile = getTile(visible.tile);
+    const startX = Math.max(0, screenLeft);
+    const endX = Math.min(width, screenLeft + TILE_SIZE);
+    const startY = Math.max(0, screenTop);
+    const endY = Math.min(height, screenTop + TILE_SIZE);
+    if (!tile) pendingRegions?.push({ left: startX, top: startY, right: endX, bottom: endY });
+
+    for (let screenY = startY; screenY < endY; screenY++) {
+      const sourceY = screenY - screenTop;
+      for (let screenX = startX; screenX < endX; screenX++) {
+        const targetOffset = (screenY * width + screenX) * 4;
+        if (!tile) {
+          fillLoadingPixel(pixels, targetOffset);
+          continue;
+        }
+        const sourceX = screenX - screenLeft;
+        const sourceOffset = (sourceY * TILE_SIZE + sourceX) * 4;
+        compositePixel(pixels, targetOffset, tile.data, sourceOffset);
+      }
+    }
+  }
+
+  return pixels;
+}
+
+/** Queue cache misses while serving completed tiles from a bounded LRU cache. */
+export class OsmTileLoader {
+  readonly getTile: TileProvider;
+  private readonly cache = new Map<string, TileImage>();
+  private readonly inFlight = new Map<string, PendingTile>();
+  private readonly maxCachedTiles: number;
+  private readonly maxConcurrentTiles: number;
+  private readonly onError: (error: unknown) => void;
+  private readonly onGenerationChange: (generation: number) => void;
+  private readonly onPendingChange: (pendingCount: number) => void;
+  private readonly onTileComplete: () => void;
+  private readonly pending = new Map<string, PendingTile>();
+  private readonly renderTile: TileRenderer;
+  private disposed = false;
+  private failed = false;
+  private generation = 0;
+
+  constructor(options: OsmTileLoaderOptions) {
+    this.maxCachedTiles = options.maxCachedTiles ?? MAX_CACHED_TILES;
+    this.maxConcurrentTiles = Math.max(1, options.maxConcurrentTiles ?? 1);
+    this.onError = options.onError ?? (() => undefined);
+    this.onGenerationChange = options.onGenerationChange ?? (() => undefined);
+    this.onPendingChange = options.onPendingChange ?? (() => undefined);
+    this.onTileComplete = options.onTileComplete ?? (() => undefined);
+    this.renderTile = options.renderTile;
+    this.getTile = (tile) => this.requestTile(tile);
+  }
+
+  get cacheSize(): number {
+    return this.cache.size;
+  }
+
+  get pendingCount(): number {
+    if (this.failed) return 0;
+    let count = 0;
+    for (const pending of this.pending.values()) {
+      if (pending.generation === this.generation) count++;
+    }
+    for (const pending of this.inFlight.values()) {
+      if (pending.generation === this.generation) count++;
+    }
+    return count;
+  }
+
+  beginFrame(generation?: number): void {
+    if (this.disposed) return;
+    const nextGeneration = generation ?? this.generation + 1;
+    if (nextGeneration === this.generation) return;
+    this.generation = nextGeneration;
+    this.onGenerationChange(nextGeneration);
+  }
+
+  endFrame(): void {
+    if (this.disposed) return;
+    for (const [key, pending] of this.pending) {
+      if (pending.generation !== this.generation) this.pending.delete(key);
+    }
+    this.processPending();
+    this.onPendingChange(this.pendingCount);
+  }
+
+  processPending(): number {
+    if (this.disposed || this.failed) return 0;
+    let started = 0;
+    while (this.inFlight.size < this.maxConcurrentTiles) {
+      const next = this.pending.entries().next().value as [string, PendingTile] | undefined;
+      if (!next) break;
+      const [key, pending] = next;
+      this.pending.delete(key);
+      if (pending.generation !== this.generation) continue;
+      this.inFlight.set(key, pending);
+      started++;
+      void Promise.resolve()
+        .then(() => this.renderTile(pending.tile, pending.generation))
+        .then((rendered) => this.completeTile(key, pending, rendered))
+        .catch((error: unknown) => this.fail(error));
+    }
+    return started;
+  }
+
+  dispose(): void {
+    this.disposed = true;
+    this.pending.clear();
+    this.inFlight.clear();
+    this.cache.clear();
+    this.onPendingChange(0);
+  }
+
+  private completeTile(key: string, pending: PendingTile, rendered: TileImage | null): void {
+    if (this.disposed || this.failed) return;
+    this.inFlight.delete(key);
+    if (!rendered) {
+      if (pending.generation === this.generation) this.pending.set(key, pending);
+      this.processPending();
+      this.onPendingChange(this.pendingCount);
+      return;
+    }
+    this.cache.set(key, rendered);
+    while (this.cache.size > this.maxCachedTiles) {
+      const oldest = this.cache.keys().next().value;
+      if (oldest === undefined) break;
+      this.cache.delete(oldest);
+    }
+    const isCurrent = pending.generation === this.generation;
+    this.processPending();
+    this.onPendingChange(this.pendingCount);
+    if (isCurrent) this.onTileComplete();
+  }
+
+  private fail(error: unknown): void {
+    if (this.disposed || this.failed) return;
+    this.failed = true;
+    this.pending.clear();
+    this.inFlight.clear();
+    this.onPendingChange(0);
+    this.onError(error);
+  }
+
+  private requestTile(tile: Tile): TileImage | null {
+    if (this.disposed) return null;
+    const key = tile.join("/");
+    const cached = this.cache.get(key);
+    if (cached) {
+      this.cache.delete(key);
+      this.cache.set(key, cached);
+      return cached;
+    }
+
+    const queued = this.pending.get(key);
+    if (queued) {
+      queued.generation = this.generation;
+      this.pending.delete(key);
+      this.pending.set(key, queued);
+      return null;
+    }
+    const rendering = this.inFlight.get(key);
+    if (rendering) rendering.generation = this.generation;
+    else this.pending.set(key, { generation: this.generation, tile });
+    return null;
+  }
+}

--- a/packages/cli/src/map-style.ts
+++ b/packages/cli/src/map-style.ts
@@ -1,0 +1,518 @@
+import {
+  matchTags,
+  type ShortbreadGeometryType,
+  type ShortbreadLayerName,
+  type ShortbreadProperties,
+  type StreetKind,
+} from "@osmix/shortbread";
+import type { OsmTags, Rgba } from "osmix";
+
+export type PointSymbol = "diamond" | "dot" | "plus" | "ring" | "square";
+export type SemanticPointCategory = "civic" | "food" | "medical" | "recreation" | "transit";
+
+interface BaseFeatureStyle {
+  order: number;
+}
+
+export interface FillFeatureStyle extends BaseFeatureStyle {
+  kind: "fill";
+  color: Rgba;
+  outlineColor?: Rgba;
+  outlineWidth?: number;
+}
+
+export interface LineFeatureStyle extends BaseFeatureStyle {
+  kind: "line";
+  color: Rgba;
+  width: number;
+  casingColor?: Rgba;
+  casingWidth?: number;
+}
+
+export interface PointFeatureStyle extends BaseFeatureStyle {
+  kind: "point";
+  color: Rgba;
+  size: number;
+  symbol: PointSymbol;
+}
+
+export type MapFeatureStyle = FillFeatureStyle | LineFeatureStyle | PointFeatureStyle;
+
+function color(hex: string, alpha = 255): Rgba {
+  return [
+    Number.parseInt(hex.slice(1, 3), 16),
+    Number.parseInt(hex.slice(3, 5), 16),
+    Number.parseInt(hex.slice(5, 7), 16),
+    alpha,
+  ];
+}
+
+const FEATURE_LIGHTENING = 0.15;
+
+function mapColor(hex: string, alpha = 255): Rgba {
+  const base = color(hex, alpha);
+  return [
+    Math.round(base[0] + (255 - base[0]) * FEATURE_LIGHTENING),
+    Math.round(base[1] + (255 - base[1]) * FEATURE_LIGHTENING),
+    Math.round(base[2] + (255 - base[2]) * FEATURE_LIGHTENING),
+    alpha,
+  ];
+}
+
+export const DARK_MAP_COLORS = {
+  background: color("#07110d"),
+  water: mapColor("#143a52"),
+  waterLine: mapColor("#4f91b3"),
+  vegetation: mapColor("#183b2a"),
+  grass: mapColor("#24492f"),
+  agriculture: mapColor("#4a4227"),
+  sand: mapColor("#655638"),
+  urban: mapColor("#292d2c"),
+  commercial: mapColor("#302d37"),
+  industrial: mapColor("#333437"),
+  site: mapColor("#2d3330"),
+  building: mapColor("#444b47"),
+  buildingOutline: mapColor("#626b65"),
+  boundary: mapColor("#8d7097", 190),
+  rail: mapColor("#9a8dac"),
+  roadCasing: mapColor("#101713"),
+  motorway: mapColor("#e47b67"),
+  primary: mapColor("#df9c68"),
+  secondary: mapColor("#d9b979"),
+  tertiary: mapColor("#c8c09a"),
+  residential: mapColor("#a8aea8"),
+  service: mapColor("#858f88"),
+  path: mapColor("#72a17b"),
+  transit: mapColor("#62c7d9"),
+  medical: mapColor("#ef7b79"),
+  civic: mapColor("#b693d6"),
+  food: mapColor("#e6a15c"),
+  recreation: mapColor("#79bd79"),
+} satisfies Record<string, Rgba>;
+
+const DATA_LAYERS = new Set<ShortbreadLayerName>([
+  "water",
+  "water_lines",
+  "land",
+  "sites",
+  "buildings",
+  "streets",
+  "aerialways",
+  "public_transport",
+  "bridges",
+  "dams",
+  "piers",
+  "ferries",
+  "boundary_lines",
+  "pois",
+]);
+
+const POLYGON_STYLE_KEYS = new Set([
+  "aeroway",
+  "amenity",
+  "landuse",
+  "leisure",
+  "man_made",
+  "natural",
+  "railway",
+  "shop",
+  "tourism",
+  "waterway",
+]);
+
+const POINT_STYLE_KEYS = new Set([
+  "aeroway",
+  "amenity",
+  "highway",
+  "historic",
+  "leisure",
+  "man_made",
+  "natural",
+  "railway",
+  "shop",
+  "tourism",
+]);
+
+const VEGETATION_KINDS = new Set([
+  "forest",
+  "wood",
+  "heath",
+  "scrub",
+  "wetland",
+  "orchard",
+  "vineyard",
+]);
+const GRASS_KINDS = new Set(["grass", "meadow", "recreation_ground", "village_green"]);
+const AGRICULTURE_KINDS = new Set(["farmland", "allotments"]);
+const SAND_KINDS = new Set(["sand", "beach", "bare_rock", "scree"]);
+const COMMERCIAL_KINDS = new Set(["commercial", "retail"]);
+const INDUSTRIAL_KINDS = new Set(["industrial", "railway", "quarry", "landfill"]);
+
+const MEDICAL_POIS = new Set([
+  "hospital",
+  "clinic",
+  "doctors",
+  "dentist",
+  "veterinary",
+  "pharmacy",
+]);
+const TRANSIT_POIS = new Set([
+  "bus_stop",
+  "bus_station",
+  "tram_stop",
+  "subway_entrance",
+  "railway_station",
+  "halt",
+  "ferry_terminal",
+  "taxi",
+]);
+const FOOD_POIS = new Set([
+  "restaurant",
+  "cafe",
+  "fast_food",
+  "bar",
+  "pub",
+  "biergarten",
+  "food_court",
+  "ice_cream",
+  "supermarket",
+  "convenience",
+  "bakery",
+  "butcher",
+  "greengrocer",
+  "kiosk",
+  "mall",
+  "department_store",
+]);
+const RECREATION_POIS = new Set([
+  "park",
+  "garden",
+  "playground",
+  "stadium",
+  "sports_centre",
+  "swimming_pool",
+  "golf_course",
+  "pitch",
+  "zoo",
+  "theme_park",
+  "attraction",
+  "viewpoint",
+]);
+const CIVIC_POIS = new Set([
+  "school",
+  "kindergarten",
+  "college",
+  "university",
+  "library",
+  "community_centre",
+  "arts_centre",
+  "place_of_worship",
+  "post_office",
+  "fire_station",
+  "police",
+  "townhall",
+  "embassy",
+  "courthouse",
+]);
+
+interface RoadDefinition {
+  color: Rgba;
+  minZoom: number;
+  casingMinZoom: number;
+  rank: number;
+  widths: [number, number, number];
+  cased: boolean;
+}
+
+function roadDefinition(kind: StreetKind): RoadDefinition {
+  if (
+    kind === "motorway" ||
+    kind === "motorway_link" ||
+    kind === "trunk" ||
+    kind === "trunk_link"
+  ) {
+    return {
+      color: DARK_MAP_COLORS.motorway,
+      minZoom: 7,
+      casingMinZoom: 8,
+      rank: 7,
+      widths: [2, 4, 5],
+      cased: true,
+    };
+  }
+  if (kind === "primary" || kind === "primary_link") {
+    return {
+      color: DARK_MAP_COLORS.primary,
+      minZoom: 8,
+      casingMinZoom: 9,
+      rank: 6,
+      widths: [1, 3, 4],
+      cased: true,
+    };
+  }
+  if (kind === "secondary" || kind === "secondary_link") {
+    return {
+      color: DARK_MAP_COLORS.secondary,
+      minZoom: 8,
+      casingMinZoom: 10,
+      rank: 5,
+      widths: [1, 2, 3],
+      cased: true,
+    };
+  }
+  if (kind === "tertiary" || kind === "tertiary_link") {
+    return {
+      color: DARK_MAP_COLORS.tertiary,
+      minZoom: 9,
+      casingMinZoom: 11,
+      rank: 4,
+      widths: [1, 2, 3],
+      cased: true,
+    };
+  }
+  if (kind === "residential" || kind === "unclassified") {
+    return {
+      color: DARK_MAP_COLORS.residential,
+      minZoom: 9,
+      casingMinZoom: 12,
+      rank: 3,
+      widths: [1, 1, 2],
+      cased: true,
+    };
+  }
+  if (kind === "service" || kind === "living_street" || kind === "pedestrian") {
+    return {
+      color: DARK_MAP_COLORS.service,
+      minZoom: 10,
+      casingMinZoom: 13,
+      rank: 2,
+      widths: [1, 1, 2],
+      cased: true,
+    };
+  }
+  return {
+    color: DARK_MAP_COLORS.path,
+    minZoom: 14,
+    casingMinZoom: Number.POSITIVE_INFINITY,
+    rank: 1,
+    widths: [1, 1, 2],
+    cased: false,
+  };
+}
+
+function hasAnyTag(tags: OsmTags, keys: ReadonlySet<string>): boolean {
+  for (const key of keys) {
+    if (key in tags) return true;
+  }
+  return false;
+}
+
+/** Cheap conservative zoom threshold used by worker-owned semantic bitsets. */
+export function potentialFeatureMinZoom(
+  tags: OsmTags,
+  geometryType: ShortbreadGeometryType,
+): number | null {
+  if (geometryType === "Point") return hasAnyTag(tags, POINT_STYLE_KEYS) ? 14 : null;
+  if (geometryType === "Polygon") {
+    let minZoom = "building" in tags ? 13 : Number.POSITIVE_INFINITY;
+    if (hasAnyTag(tags, POLYGON_STYLE_KEYS)) minZoom = 0;
+    return Number.isFinite(minZoom) ? minZoom : null;
+  }
+
+  let minZoom = Number.POSITIVE_INFINITY;
+  if ("waterway" in tags || "man_made" in tags) minZoom = 0;
+  if ("boundary" in tags) minZoom = Math.min(minZoom, 4);
+  const highway = tags["highway"];
+  if (highway) minZoom = Math.min(minZoom, roadDefinition(highway as StreetKind).minZoom);
+  if ("railway" in tags || "route" in tags) minZoom = Math.min(minZoom, 9);
+  if ("aerialway" in tags) minZoom = Math.min(minZoom, 12);
+  return Number.isFinite(minZoom) ? minZoom : null;
+}
+
+function mayHaveFeatureStyle(
+  tags: OsmTags,
+  geometryType: ShortbreadGeometryType,
+  zoom: number,
+): boolean {
+  const minZoom = potentialFeatureMinZoom(tags, geometryType);
+  return minZoom !== null && zoom >= minZoom;
+}
+
+function widthAtZoom(widths: RoadDefinition["widths"], zoom: number): number {
+  if (zoom >= 16) return widths[2];
+  if (zoom >= 14) return widths[1];
+  return widths[0];
+}
+
+function muted(colorValue: Rgba): Rgba {
+  return [
+    Math.round((colorValue[0]! + DARK_MAP_COLORS.background[0]!) / 2),
+    Math.round((colorValue[1]! + DARK_MAP_COLORS.background[1]!) / 2),
+    Math.round((colorValue[2]! + DARK_MAP_COLORS.background[2]!) / 2),
+    255,
+  ];
+}
+
+function landColor(kind: string): Rgba {
+  if (VEGETATION_KINDS.has(kind)) return DARK_MAP_COLORS.vegetation;
+  if (GRASS_KINDS.has(kind)) return DARK_MAP_COLORS.grass;
+  if (AGRICULTURE_KINDS.has(kind)) return DARK_MAP_COLORS.agriculture;
+  if (SAND_KINDS.has(kind)) return DARK_MAP_COLORS.sand;
+  if (COMMERCIAL_KINDS.has(kind)) return DARK_MAP_COLORS.commercial;
+  if (INDUSTRIAL_KINDS.has(kind)) return DARK_MAP_COLORS.industrial;
+  return DARK_MAP_COLORS.urban;
+}
+
+function siteColor(kind: string): Rgba {
+  if (["park", "garden", "playground", "golf_course", "pitch"].includes(kind)) {
+    return DARK_MAP_COLORS.grass;
+  }
+  if (["hospital", "prison"].includes(kind)) return mapColor("#3d292d");
+  if (["university", "school", "college", "kindergarten"].includes(kind)) {
+    return mapColor("#30303d");
+  }
+  return DARK_MAP_COLORS.site;
+}
+
+export function semanticPointCategory(kind: string): SemanticPointCategory | null {
+  if (TRANSIT_POIS.has(kind)) return "transit";
+  if (MEDICAL_POIS.has(kind)) return "medical";
+  if (CIVIC_POIS.has(kind)) return "civic";
+  if (FOOD_POIS.has(kind)) return "food";
+  if (RECREATION_POIS.has(kind)) return "recreation";
+  return null;
+}
+
+function pointStyle(kind: string, zoom: number): PointFeatureStyle | null {
+  const size = zoom >= 16 ? 2 : 1;
+  switch (semanticPointCategory(kind)) {
+    case "transit":
+      return { kind: "point", order: 600, color: DARK_MAP_COLORS.transit, size, symbol: "diamond" };
+    case "medical":
+      return { kind: "point", order: 601, color: DARK_MAP_COLORS.medical, size, symbol: "plus" };
+    case "civic":
+      return { kind: "point", order: 602, color: DARK_MAP_COLORS.civic, size, symbol: "square" };
+    case "food":
+      return { kind: "point", order: 603, color: DARK_MAP_COLORS.food, size, symbol: "dot" };
+    case "recreation":
+      return { kind: "point", order: 604, color: DARK_MAP_COLORS.recreation, size, symbol: "ring" };
+    default:
+      return null;
+  }
+}
+
+function styleMatch(
+  layer: ShortbreadLayerName,
+  properties: ShortbreadProperties,
+  geometryType: ShortbreadGeometryType,
+  zoom: number,
+): MapFeatureStyle | null {
+  const kind = properties.kind;
+  switch (layer) {
+    case "land":
+      return { kind: "fill", order: 10, color: landColor(kind) };
+    case "sites":
+      return { kind: "fill", order: 20, color: siteColor(kind) };
+    case "water":
+      return { kind: "fill", order: 30, color: DARK_MAP_COLORS.water };
+    case "dams":
+      if (properties.kind !== "dam") return null;
+      return geometryType === "Polygon"
+        ? { kind: "fill", order: 35, color: DARK_MAP_COLORS.waterLine }
+        : { kind: "line", order: 70, color: DARK_MAP_COLORS.waterLine, width: 2 };
+    case "piers":
+      return geometryType === "Polygon"
+        ? { kind: "fill", order: 36, color: DARK_MAP_COLORS.buildingOutline }
+        : { kind: "line", order: 71, color: DARK_MAP_COLORS.buildingOutline, width: 2 };
+    case "water_lines":
+      return {
+        kind: "line",
+        order: 60,
+        color: DARK_MAP_COLORS.waterLine,
+        width: kind === "river" ? 2 : 1,
+      };
+    case "buildings":
+      if (zoom < 13) return null;
+      return {
+        kind: "fill",
+        order: 40,
+        color: DARK_MAP_COLORS.building,
+        outlineColor: DARK_MAP_COLORS.buildingOutline,
+        outlineWidth: 1,
+      };
+    case "bridges":
+      if (zoom < 12) return null;
+      return {
+        kind: "fill",
+        order: 45,
+        color: DARK_MAP_COLORS.site,
+        outlineColor: DARK_MAP_COLORS.buildingOutline,
+        outlineWidth: 1,
+      };
+    case "boundary_lines": {
+      const adminLevel = "admin_level" in properties ? properties.admin_level : undefined;
+      const minZoom = adminLevel === undefined || adminLevel <= 2 ? 4 : adminLevel <= 4 ? 8 : 12;
+      if (zoom < minZoom) return null;
+      return {
+        kind: "line",
+        order: 100,
+        color: DARK_MAP_COLORS.boundary,
+        width: adminLevel && adminLevel <= 2 ? 2 : 1,
+      };
+    }
+    case "streets": {
+      const definition = roadDefinition(kind as StreetKind);
+      if (zoom < definition.minZoom) return null;
+      const width = widthAtZoom(definition.widths, zoom);
+      const isTunnel = "tunnel" in properties && properties.tunnel === true;
+      const isBridge = "bridge" in properties && properties.bridge === true;
+      const phase = isTunnel ? 200 : isBridge ? 400 : 300;
+      const roadColor = isTunnel ? muted(definition.color) : definition.color;
+      const hasCasing = definition.cased && zoom >= definition.casingMinZoom;
+      return {
+        kind: "line",
+        order: phase + definition.rank,
+        color: roadColor,
+        width,
+        casingColor: hasCasing ? DARK_MAP_COLORS.roadCasing : undefined,
+        casingWidth: hasCasing ? width + 2 : undefined,
+      };
+    }
+    case "public_transport":
+      if (zoom < 9) return null;
+      return {
+        kind: "line",
+        order: 500,
+        color: DARK_MAP_COLORS.rail,
+        width: zoom >= 16 ? 2 : 1,
+        casingColor: zoom >= 11 ? DARK_MAP_COLORS.roadCasing : undefined,
+        casingWidth: zoom >= 11 ? (zoom >= 16 ? 4 : 3) : undefined,
+      };
+    case "aerialways":
+      if (zoom < 12) return null;
+      return { kind: "line", order: 510, color: DARK_MAP_COLORS.civic, width: 1 };
+    case "ferries":
+      if (zoom < 9) return null;
+      return { kind: "line", order: 520, color: DARK_MAP_COLORS.transit, width: 1 };
+    case "pois":
+      return zoom >= 14 ? pointStyle(kind, zoom) : null;
+    default:
+      return null;
+  }
+}
+
+/** Classify OSM tags and resolve the built-in dark basemap styles for a zoom level. */
+export function resolveFeatureStyles(
+  tags: OsmTags,
+  geometryType: ShortbreadGeometryType,
+  zoom: number,
+): MapFeatureStyle[] {
+  if (!mayHaveFeatureStyle(tags, geometryType, zoom)) return [];
+  const styles: MapFeatureStyle[] = [];
+  for (const match of matchTags(tags, geometryType)) {
+    if (!DATA_LAYERS.has(match.layer.name)) continue;
+    const style = styleMatch(match.layer.name, match.properties, geometryType, zoom);
+    if (style) styles.push(style);
+  }
+  return styles;
+}

--- a/packages/cli/src/semantic-label-index.ts
+++ b/packages/cli/src/semantic-label-index.ts
@@ -1,0 +1,150 @@
+import { wayIsArea } from "@osmix/geo/way-is-area";
+import {
+  SHORTBREAD_GEOMETRY_MASK,
+  ShortbreadFeatureIndex,
+  type ShortbreadFeatureEntityType,
+  type ShortbreadGeometryType,
+} from "@osmix/shortbread";
+import type { GeoBbox2D, Osm } from "osmix";
+
+import { resolveIndexedLabelMetadata, type MapLabelSpatialIndexProvider } from "./map-labels.ts";
+
+const WORLD_BBOX: GeoBbox2D = [-180, -90, 180, 90];
+
+function geometryType(mask: number): ShortbreadGeometryType | null {
+  if ((mask & SHORTBREAD_GEOMETRY_MASK.POLYGON) !== 0) return "Polygon";
+  if ((mask & SHORTBREAD_GEOMETRY_MASK.LINE_STRING) !== 0) return "LineString";
+  if ((mask & SHORTBREAD_GEOMETRY_MASK.POINT) !== 0) return "Point";
+  return null;
+}
+
+class ZoomedEntityLabelIndex implements MapLabelSpatialIndexProvider {
+  private readonly index: EntityLabelIndex;
+  private readonly zoom: number;
+
+  constructor(index: EntityLabelIndex, zoom: number) {
+    this.index = index;
+    this.zoom = zoom;
+  }
+
+  intersects(bbox: GeoBbox2D): number[] {
+    return this.index.intersects(bbox, this.zoom);
+  }
+}
+
+class EntityLabelIndex {
+  readonly size: number;
+  private readonly entityType: ShortbreadFeatureEntityType;
+  private readonly featureIndex: ShortbreadFeatureIndex;
+  private readonly indexes: Uint32Array;
+  private readonly minZooms: Uint8Array;
+
+  private constructor(
+    featureIndex: ShortbreadFeatureIndex,
+    entityType: ShortbreadFeatureEntityType,
+    indexes: Uint32Array,
+    minZooms: Uint8Array,
+  ) {
+    this.featureIndex = featureIndex;
+    this.entityType = entityType;
+    this.indexes = indexes;
+    this.minZooms = minZooms;
+    this.size = indexes.length;
+  }
+
+  static buildWays(osm: Osm, featureIndex: ShortbreadFeatureIndex): EntityLabelIndex {
+    const indexes: number[] = [];
+    const minZooms: number[] = [];
+    for (const entityIndex of featureIndex.queryEntityIndexes(WORLD_BBOX, "way")) {
+      const way = osm.ways.getByIndex(entityIndex);
+      if (!way.tags) continue;
+      const metadata = resolveIndexedLabelMetadata(
+        way.tags,
+        wayIsArea(way) ? "Polygon" : "LineString",
+      );
+      if (!metadata) continue;
+      indexes.push(entityIndex);
+      minZooms.push(metadata.minZoom);
+    }
+    return new EntityLabelIndex(
+      featureIndex,
+      "way",
+      Uint32Array.from(indexes),
+      Uint8Array.from(minZooms),
+    );
+  }
+
+  static buildRelations(osm: Osm, featureIndex: ShortbreadFeatureIndex): EntityLabelIndex {
+    const indexes: number[] = [];
+    const minZooms: number[] = [];
+    for (const record of featureIndex.query(WORLD_BBOX)) {
+      if (record.entityType !== "relation") continue;
+      const tags = osm.relations.tags.getTags(record.entityIndex);
+      const type = geometryType(record.geometryMask);
+      if (!tags || !type) continue;
+      const metadata = resolveIndexedLabelMetadata(tags, type);
+      if (!metadata) continue;
+      indexes.push(record.entityIndex);
+      minZooms.push(metadata.minZoom);
+    }
+    return new EntityLabelIndex(
+      featureIndex,
+      "relation",
+      Uint32Array.from(indexes),
+      Uint8Array.from(minZooms),
+    );
+  }
+
+  atZoom(zoom: number): MapLabelSpatialIndexProvider {
+    return new ZoomedEntityLabelIndex(this, zoom);
+  }
+
+  intersects(bbox: GeoBbox2D, zoom: number): number[] {
+    return this.featureIndex.queryEntityIndexes(bbox, this.entityType, (entityIndex) => {
+      const position = this.position(entityIndex);
+      return position >= 0 && zoom >= this.minZooms[position]!;
+    });
+  }
+
+  private position(entityIndex: number): number {
+    let low = 0;
+    let high = this.indexes.length - 1;
+    while (low <= high) {
+      const middle = (low + high) >>> 1;
+      const candidate = this.indexes[middle]!;
+      if (candidate === entityIndex) return middle;
+      if (candidate < entityIndex) low = middle + 1;
+      else high = middle - 1;
+    }
+    return -1;
+  }
+}
+
+/** Worker-owned CLI label metadata over the shared Shortbread feature index. */
+export class SemanticLabelIndex {
+  readonly relationCount: number;
+  readonly wayCount: number;
+  private readonly relations: EntityLabelIndex;
+  private readonly ways: EntityLabelIndex;
+
+  private constructor(relations: EntityLabelIndex, ways: EntityLabelIndex) {
+    this.relations = relations;
+    this.ways = ways;
+    this.relationCount = relations.size;
+    this.wayCount = ways.size;
+  }
+
+  static build(osm: Osm, featureIndex = ShortbreadFeatureIndex.build(osm)): SemanticLabelIndex {
+    return new SemanticLabelIndex(
+      EntityLabelIndex.buildRelations(osm, featureIndex),
+      EntityLabelIndex.buildWays(osm, featureIndex),
+    );
+  }
+
+  providers(zoom: number): {
+    relations: MapLabelSpatialIndexProvider;
+    ways: MapLabelSpatialIndexProvider;
+  } {
+    return { relations: this.relations.atZoom(zoom), ways: this.ways.atZoom(zoom) };
+  }
+}

--- a/packages/cli/src/semantic-node-index.ts
+++ b/packages/cli/src/semantic-node-index.ts
@@ -1,0 +1,158 @@
+import {
+  ShortbreadFeatureIndex,
+  type ShortbreadFeatureIndexTransferables,
+} from "@osmix/shortbread";
+import { BufferConstructor, type BufferType, type GeoBbox2D, type LonLat, type Osm } from "osmix";
+
+import {
+  resolveIndexedLabelMetadata,
+  type IndexedMapLabelMetadata,
+  type IndexedMapLabelNode,
+} from "./map-labels.ts";
+import { resolveFeatureStyles } from "./map-style.ts";
+
+const WORLD_BBOX: GeoBbox2D = [-180, -90, 180, 90];
+
+export interface SemanticNodeIndexTransferables {
+  featureIndex: ShortbreadFeatureIndexTransferables;
+  indexes: BufferType;
+}
+
+function sharedIndexes(values: number[]): Uint32Array {
+  const result = new Uint32Array(
+    new BufferConstructor(values.length * Uint32Array.BYTES_PER_ELEMENT),
+  );
+  result.set(values);
+  return result;
+}
+
+/** CLI point-style and label metadata over the shared Shortbread spatial candidate index. */
+export class SemanticNodeIndex {
+  readonly labelCount: number;
+  readonly size: number;
+
+  private readonly featureIndex: ShortbreadFeatureIndex;
+  private readonly ids: Float64Array;
+  private readonly indexes: Uint32Array;
+  private readonly labels: (IndexedMapLabelMetadata | null)[];
+  private readonly lats: Float64Array;
+  private readonly lons: Float64Array;
+
+  private constructor(
+    featureIndex: ShortbreadFeatureIndex,
+    indexes: Uint32Array,
+    ids: Float64Array,
+    lons: Float64Array,
+    lats: Float64Array,
+    labels: (IndexedMapLabelMetadata | null)[],
+  ) {
+    this.featureIndex = featureIndex;
+    this.indexes = indexes;
+    this.ids = ids;
+    this.lons = lons;
+    this.lats = lats;
+    this.labels = labels;
+    this.size = indexes.length;
+    this.labelCount = labels.reduce((count, label) => count + (label ? 1 : 0), 0);
+  }
+
+  static build(osm: Osm, featureIndex = ShortbreadFeatureIndex.build(osm)): SemanticNodeIndex {
+    const indexes: number[] = [];
+    const ids: number[] = [];
+    const lons: number[] = [];
+    const lats: number[] = [];
+    const labels: (IndexedMapLabelMetadata | null)[] = [];
+    for (const nodeIndex of featureIndex.queryEntityIndexes(WORLD_BBOX, "node")) {
+      const tags = osm.nodes.tags.getTags(nodeIndex);
+      if (!tags) continue;
+      const label = resolveIndexedLabelMetadata(tags, "Point");
+      const hasPointStyle = resolveFeatureStyles(tags, "Point", 20).some(
+        (style) => style.kind === "point",
+      );
+      if (!label && !hasPointStyle) continue;
+
+      const [lon, lat] = osm.nodes.getNodeLonLat({ index: nodeIndex });
+      indexes.push(nodeIndex);
+      ids.push(osm.nodes.ids.at(nodeIndex));
+      lons.push(lon);
+      lats.push(lat);
+      labels.push(label);
+    }
+
+    return new SemanticNodeIndex(
+      featureIndex,
+      sharedIndexes(indexes),
+      Float64Array.from(ids),
+      Float64Array.from(lons),
+      Float64Array.from(lats),
+      labels,
+    );
+  }
+
+  static fromTransferables(
+    transferables: SemanticNodeIndexTransferables,
+    featureIndex = ShortbreadFeatureIndex.fromTransferables(transferables.featureIndex),
+  ): SemanticNodeIndex {
+    return new SemanticNodeIndex(
+      featureIndex,
+      new Uint32Array(transferables.indexes),
+      new Float64Array(0),
+      new Float64Array(0),
+      new Float64Array(0),
+      [],
+    );
+  }
+
+  /** Structurally implements the styled tile renderer's optional node provider. */
+  findIndexesWithinBbox(bbox: GeoBbox2D): number[] {
+    return this.featureIndex.queryEntityIndexes(
+      bbox,
+      "node",
+      (entityIndex) => this.position(entityIndex) >= 0,
+    );
+  }
+
+  transferables(): SemanticNodeIndexTransferables {
+    return {
+      featureIndex: this.featureIndex.transferables(),
+      indexes: this.indexes.buffer as BufferType,
+    };
+  }
+
+  /** Return only visible, zoom-eligible, already-classified label nodes. */
+  findLabelNodes(bboxes: GeoBbox2D[], zoom: number): IndexedMapLabelNode[] {
+    const visibleIndexes = new Set<number>();
+    for (const bbox of bboxes) {
+      for (const entityIndex of this.featureIndex.queryEntityIndexes(bbox, "node")) {
+        visibleIndexes.add(entityIndex);
+      }
+    }
+
+    const nodes: IndexedMapLabelNode[] = [];
+    for (const entityIndex of [...visibleIndexes].sort((a, b) => a - b)) {
+      const position = this.position(entityIndex);
+      if (position < 0) continue;
+      const metadata = this.labels[position];
+      if (!metadata || zoom < metadata.minZoom) continue;
+      nodes.push({
+        coordinate: [this.lons[position]!, this.lats[position]!] satisfies LonLat,
+        id: this.ids[position]!,
+        metadata,
+      });
+    }
+    return nodes;
+  }
+
+  private position(entityIndex: number): number {
+    let low = 0;
+    let high = this.indexes.length - 1;
+    while (low <= high) {
+      const middle = (low + high) >>> 1;
+      const candidate = this.indexes[middle]!;
+      if (candidate === entityIndex) return middle;
+      if (candidate < entityIndex) low = middle + 1;
+      else high = middle - 1;
+    }
+    return -1;
+  }
+}

--- a/packages/cli/src/semantic-render-index.ts
+++ b/packages/cli/src/semantic-render-index.ts
@@ -1,0 +1,126 @@
+import {
+  type ShortbreadFeatureEntityType,
+  ShortbreadFeatureIndex,
+  type ShortbreadFeatureIndexTransferables,
+} from "@osmix/shortbread";
+import { BufferConstructor, type BufferType, type GeoBbox2D, type Osm } from "osmix";
+
+import { potentialFeatureMinZoom } from "./map-style.ts";
+
+const HIDDEN_ZOOM = 255;
+const WORLD_BBOX: GeoBbox2D = [-180, -90, 180, 90];
+
+export interface SemanticRenderIndexTransferables {
+  featureIndex: ShortbreadFeatureIndexTransferables;
+  relations: BufferType;
+  ways: BufferType;
+}
+
+interface SpatialEntities {
+  intersects(bbox: GeoBbox2D, filter?: (index: number) => boolean): number[];
+}
+
+export interface ZoomFilteredSpatialIndex {
+  intersects(bbox: GeoBbox2D): number[];
+}
+
+function minimumZoom(tags: ReturnType<Osm["ways"]["tags"]["getTags"]>): number {
+  if (!tags) return HIDDEN_ZOOM;
+  let result = HIDDEN_ZOOM;
+  for (const geometryType of ["Polygon", "LineString", "Point"] as const) {
+    const candidate = potentialFeatureMinZoom(tags, geometryType);
+    if (candidate !== null) result = Math.min(result, candidate);
+  }
+  return result;
+}
+
+function buildMinimumZooms(
+  osm: Osm,
+  featureIndex: ShortbreadFeatureIndex,
+  entityType: "way" | "relation",
+): Uint8Array {
+  const entities = entityType === "way" ? osm.ways : osm.relations;
+  const result = new Uint8Array(new BufferConstructor(entities.size));
+  result.fill(HIDDEN_ZOOM);
+  for (const entityIndex of featureIndex.queryEntityIndexes(WORLD_BBOX, entityType)) {
+    result[entityIndex] = minimumZoom(entities.tags.getTags(entityIndex));
+  }
+  return result;
+}
+
+/** CLI minimum-zoom metadata over the shared Shortbread spatial candidate index. */
+export class SemanticRenderIndex {
+  readonly relationCount: number;
+  readonly wayCount: number;
+  private readonly featureIndex: ShortbreadFeatureIndex;
+  private readonly relationMinimumZooms: Uint8Array;
+  private readonly wayMinimumZooms: Uint8Array;
+
+  private constructor(
+    featureIndex: ShortbreadFeatureIndex,
+    wayMinimumZooms: Uint8Array,
+    relationMinimumZooms: Uint8Array,
+  ) {
+    this.featureIndex = featureIndex;
+    this.wayMinimumZooms = wayMinimumZooms;
+    this.relationMinimumZooms = relationMinimumZooms;
+    this.wayCount = this.visibleCount(wayMinimumZooms);
+    this.relationCount = this.visibleCount(relationMinimumZooms);
+  }
+
+  static build(osm: Osm, featureIndex = ShortbreadFeatureIndex.build(osm)): SemanticRenderIndex {
+    return new SemanticRenderIndex(
+      featureIndex,
+      buildMinimumZooms(osm, featureIndex, "way"),
+      buildMinimumZooms(osm, featureIndex, "relation"),
+    );
+  }
+
+  static fromTransferables(
+    transferables: SemanticRenderIndexTransferables,
+    featureIndex = ShortbreadFeatureIndex.fromTransferables(transferables.featureIndex),
+  ): SemanticRenderIndex {
+    return new SemanticRenderIndex(
+      featureIndex,
+      new Uint8Array(transferables.ways),
+      new Uint8Array(transferables.relations),
+    );
+  }
+
+  relations(_entities: SpatialEntities, zoom: number): ZoomFilteredSpatialIndex {
+    return this.provider("relation", this.relationMinimumZooms, zoom);
+  }
+
+  transferables(): SemanticRenderIndexTransferables {
+    return {
+      featureIndex: this.featureIndex.transferables(),
+      ways: this.wayMinimumZooms.buffer as BufferType,
+      relations: this.relationMinimumZooms.buffer as BufferType,
+    };
+  }
+
+  ways(_entities: SpatialEntities, zoom: number): ZoomFilteredSpatialIndex {
+    return this.provider("way", this.wayMinimumZooms, zoom);
+  }
+
+  private provider(
+    entityType: ShortbreadFeatureEntityType,
+    minimumZooms: Uint8Array,
+    zoom: number,
+  ): ZoomFilteredSpatialIndex {
+    return {
+      intersects: (bbox) =>
+        this.featureIndex.queryEntityIndexes(
+          bbox,
+          entityType,
+          (entityIndex) => minimumZooms[entityIndex]! <= zoom,
+        ),
+    };
+  }
+
+  private visibleCount(minimumZooms: Uint8Array): number {
+    let count = 0;
+    for (const minZoom of minimumZooms) if (minZoom !== HIDDEN_ZOOM) count++;
+    return count;
+  }
+}

--- a/packages/cli/src/styled-tile.ts
+++ b/packages/cli/src/styled-tile.ts
@@ -1,0 +1,376 @@
+import { wayIsArea } from "@osmix/geo/way-is-area";
+import { runCooperatively } from "@osmix/shared/cooperative";
+import type { ShortbreadGeometryType } from "@osmix/shortbread";
+import {
+  OsmixRasterTile,
+  type GeoBbox2D,
+  type LonLat,
+  type Osm,
+  type OsmTags,
+  type Rgba,
+  type Tile,
+  type XY,
+} from "osmix";
+
+import {
+  resolveFeatureStyles,
+  type LineFeatureStyle,
+  type MapFeatureStyle,
+  type PointFeatureStyle,
+} from "./map-style.ts";
+
+interface DrawCommand {
+  index: number;
+  order: number;
+  draw: (rasterTile: OsmixRasterTile) => void;
+}
+
+interface StyledTileJob {
+  isCancelled: () => boolean;
+  iterator: Generator<void, void>;
+  rasterTile: OsmixRasterTile;
+}
+
+/** Internal scheduling hooks used by the worker's cooperative renderer and its tests. */
+export interface StyledTileAsyncOptions {
+  chunkBudgetMs?: number;
+  now?: () => number;
+  yieldToEventLoop?: () => Promise<void>;
+}
+
+/** A compact node index may be supplied when the full OSM node index is unavailable. */
+export interface StyledTileNodeIndexProvider {
+  findIndexesWithinBbox(bbox: GeoBbox2D): Iterable<number>;
+}
+
+export interface StyledTileSpatialIndexProvider {
+  intersects(bbox: GeoBbox2D): Iterable<number>;
+}
+
+export interface StyledTileFeatureIndexProviders {
+  relations?: StyledTileSpatialIndexProvider;
+  ways?: StyledTileSpatialIndexProvider;
+}
+
+function drawLines(
+  rasterTile: OsmixRasterTile,
+  lineStrings: LonLat[][],
+  style: LineFeatureStyle,
+): void {
+  for (const lineString of lineStrings) {
+    if (style.casingColor && style.casingWidth) {
+      rasterTile.drawLineString(lineString, style.casingColor, style.casingWidth);
+    }
+    rasterTile.drawLineString(lineString, style.color, style.width);
+  }
+}
+
+function drawSymbolPixel(rasterTile: OsmixRasterTile, pixel: XY, color: Rgba): void {
+  if (
+    pixel[0] < 0 ||
+    pixel[0] >= rasterTile.tileSize ||
+    pixel[1] < 0 ||
+    pixel[1] >= rasterTile.tileSize
+  ) {
+    return;
+  }
+  rasterTile.drawPixel(pixel, color);
+}
+
+function drawPointSymbol(
+  rasterTile: OsmixRasterTile,
+  point: LonLat,
+  style: PointFeatureStyle,
+): void {
+  const center = rasterTile.clampAndRoundPx(rasterTile.llToTilePx(point));
+  if (style.symbol === "dot") {
+    rasterTile.drawPoint(point, style.color, style.size - 1);
+    return;
+  }
+
+  for (let y = -style.size; y <= style.size; y++) {
+    for (let x = -style.size; x <= style.size; x++) {
+      const absoluteX = Math.abs(x);
+      const absoluteY = Math.abs(y);
+      const shouldDraw =
+        (style.symbol === "diamond" && absoluteX + absoluteY <= style.size) ||
+        (style.symbol === "plus" && (x === 0 || y === 0)) ||
+        style.symbol === "square" ||
+        (style.symbol === "ring" && Math.max(absoluteX, absoluteY) === style.size);
+      if (shouldDraw) {
+        drawSymbolPixel(rasterTile, [center[0] + x, center[1] + y], style.color);
+      }
+    }
+  }
+}
+
+function addPolygonCommands(
+  commands: DrawCommand[],
+  polygons: LonLat[][][],
+  styles: MapFeatureStyle[],
+): void {
+  for (const style of styles) {
+    if (style.kind === "fill") {
+      for (const polygon of polygons) {
+        commands.push({
+          draw: (tile) => tile.drawPolygon(polygon, style.color),
+          index: commands.length,
+          order: style.order,
+        });
+      }
+      if (!style.outlineColor || !style.outlineWidth) continue;
+      for (const polygon of polygons) {
+        for (const ring of polygon) {
+          commands.push({
+            draw: (tile) => tile.drawLineString(ring, style.outlineColor, style.outlineWidth),
+            index: commands.length,
+            order: style.order,
+          });
+        }
+      }
+    } else if (style.kind === "line") {
+      for (const polygon of polygons) {
+        for (const ring of polygon) {
+          commands.push({
+            draw: (tile) => drawLines(tile, [ring], style),
+            index: commands.length,
+            order: style.order,
+          });
+        }
+      }
+    }
+  }
+}
+
+function addLineCommands(
+  commands: DrawCommand[],
+  lineStrings: LonLat[][],
+  styles: MapFeatureStyle[],
+): void {
+  for (const style of styles) {
+    if (style.kind !== "line") continue;
+    for (const lineString of lineStrings) {
+      commands.push({
+        draw: (tile) => drawLines(tile, [lineString], style),
+        index: commands.length,
+        order: style.order,
+      });
+    }
+  }
+}
+
+function addPointCommands(
+  commands: DrawCommand[],
+  points: LonLat[],
+  styles: MapFeatureStyle[],
+): void {
+  for (const style of styles) {
+    if (style.kind !== "point") continue;
+    for (const point of points) {
+      commands.push({
+        draw: (tile) => drawPointSymbol(tile, point, style),
+        index: commands.length,
+        order: style.order,
+      });
+    }
+  }
+}
+
+function geometryStyles(
+  tags: OsmTags | undefined,
+  geometryType: ShortbreadGeometryType,
+  zoom: number,
+): MapFeatureStyle[] {
+  if (!tags || Object.keys(tags).length === 0) return [];
+  return resolveFeatureStyles(tags, geometryType, zoom);
+}
+
+function createStyledTileJob(
+  osm: Osm,
+  tile: Tile,
+  tileSize: number,
+  nodeIndexProvider: StyledTileNodeIndexProvider | undefined,
+  featureIndexes: StyledTileFeatureIndexProviders,
+  isCancelled: () => boolean,
+): StyledTileJob {
+  const rasterTile = new OsmixRasterTile({ tile, tileSize });
+  return {
+    isCancelled,
+    iterator: collectAndDrawTileSteps(
+      osm,
+      rasterTile,
+      nodeIndexProvider,
+      featureIndexes,
+      isCancelled,
+    ),
+    rasterTile,
+  };
+}
+
+function* collectAndDrawTileSteps(
+  osm: Osm,
+  rasterTile: OsmixRasterTile,
+  nodeIndexProvider: StyledTileNodeIndexProvider | undefined,
+  featureIndexes: StyledTileFeatureIndexProviders,
+  isCancelled: () => boolean,
+): Generator<void, void> {
+  const bbox = rasterTile.bbox();
+  const zoom = rasterTile.tile[2];
+  const commands: DrawCommand[] = [];
+  const suppressedAreaWayIds = new Set<number>();
+  const relationIndexes = [...(featureIndexes.relations ?? osm.relations).intersects(bbox)].sort(
+    (a, b) => a - b,
+  );
+
+  for (const relationIndex of relationIndexes) {
+    if (isCancelled()) return;
+    const tags = osm.relations.tags.getTags(relationIndex);
+    const polygonStyles = geometryStyles(tags, "Polygon", zoom);
+    const lineStyles = geometryStyles(tags, "LineString", zoom);
+    const pointStyles = geometryStyles(tags, "Point", zoom);
+    if (polygonStyles.length === 0 && lineStyles.length === 0 && pointStyles.length === 0) {
+      yield;
+      continue;
+    }
+    const geometry = osm.relations.getRelationGeometry(relationIndex);
+    if (geometry.rings) {
+      if (polygonStyles.length > 0) {
+        for (const member of osm.relations.getMembersByIndex(relationIndex)) {
+          if (member.type === "way") suppressedAreaWayIds.add(member.ref);
+        }
+        addPolygonCommands(commands, geometry.rings, polygonStyles);
+      }
+    }
+    if (geometry.lineStrings) {
+      addLineCommands(commands, geometry.lineStrings, lineStyles);
+    }
+    if (geometry.points) {
+      addPointCommands(commands, geometry.points, pointStyles);
+    }
+    yield;
+  }
+
+  const wayIndexes = [...(featureIndexes.ways ?? osm.ways).intersects(bbox)].sort((a, b) => a - b);
+  for (const wayIndex of wayIndexes) {
+    if (isCancelled()) return;
+    const tags = osm.ways.tags.getTags(wayIndex);
+    if (!tags || Object.keys(tags).length === 0) {
+      yield;
+      continue;
+    }
+    const polygonStyles = geometryStyles(tags, "Polygon", zoom);
+    const lineStyles = geometryStyles(tags, "LineString", zoom);
+    if (polygonStyles.length === 0 && lineStyles.length === 0) {
+      yield;
+      continue;
+    }
+    const way = osm.ways.getFullEntity(wayIndex, osm.ways.ids.at(wayIndex), tags);
+    const isArea = wayIsArea(way);
+    if (isArea && suppressedAreaWayIds.has(way.id)) {
+      yield;
+      continue;
+    }
+    const styles = isArea ? polygonStyles : lineStyles;
+    if (styles.length === 0) {
+      yield;
+      continue;
+    }
+    const coordinates = osm.ways.getCoordinates(wayIndex);
+    if (isArea) {
+      addPolygonCommands(commands, [[coordinates]], styles);
+    } else {
+      addLineCommands(commands, [coordinates], styles);
+    }
+    yield;
+  }
+
+  if (zoom >= 14) {
+    const nodeIndexes = nodeIndexProvider
+      ? nodeIndexProvider.findIndexesWithinBbox(bbox)
+      : osm.nodes.findIndexesWithinBbox(bbox);
+    for (const nodeIndex of [...nodeIndexes].sort((a, b) => a - b)) {
+      if (isCancelled()) return;
+      const tags = osm.nodes.tags.getTags(nodeIndex);
+      const styles = geometryStyles(tags, "Point", zoom);
+      if (styles.length > 0) {
+        addPointCommands(commands, [osm.nodes.getNodeLonLat({ index: nodeIndex })], styles);
+      }
+      yield;
+    }
+  }
+
+  commands.sort((a, b) => a.order - b.order || a.index - b.index);
+  for (const command of commands) {
+    if (isCancelled()) return;
+    command.draw(rasterTile);
+    yield;
+  }
+}
+
+function currentTimeMs(): number {
+  return globalThis.performance?.now() ?? Date.now();
+}
+
+function runStyledTileChunk(job: StyledTileJob, chunkBudgetMs: number, now: () => number): boolean {
+  if (job.isCancelled()) {
+    job.iterator.return();
+    return true;
+  }
+  const startedAt = now();
+  do {
+    if (job.isCancelled()) {
+      job.iterator.return();
+      return true;
+    }
+    if (job.iterator.next().done) return true;
+  } while (now() - startedAt < chunkBudgetMs);
+  return false;
+}
+
+/** Render one semantic dark-basemap XYZ tile from an indexed OSM dataset. */
+export function drawStyledMapTile(
+  osm: Osm,
+  tile: Tile,
+  tileSize = 256,
+  nodeIndexProvider?: StyledTileNodeIndexProvider,
+  featureIndexes: StyledTileFeatureIndexProviders = {},
+  isCancelled: () => boolean = () => false,
+): OsmixRasterTile {
+  const job = createStyledTileJob(
+    osm,
+    tile,
+    tileSize,
+    nodeIndexProvider,
+    featureIndexes,
+    isCancelled,
+  );
+  runStyledTileChunk(job, Number.POSITIVE_INFINITY, currentTimeMs);
+  return job.rasterTile;
+}
+
+/** Worker-only renderer that yields between bounded chunks so cancellation RPCs can run. */
+export async function drawStyledMapTileAsync(
+  osm: Osm,
+  tile: Tile,
+  tileSize = 256,
+  nodeIndexProvider?: StyledTileNodeIndexProvider,
+  featureIndexes: StyledTileFeatureIndexProviders = {},
+  isCancelled: () => boolean = () => false,
+  options: StyledTileAsyncOptions = {},
+): Promise<OsmixRasterTile> {
+  const job = createStyledTileJob(
+    osm,
+    tile,
+    tileSize,
+    nodeIndexProvider,
+    featureIndexes,
+    isCancelled,
+  );
+  await runCooperatively(job.iterator, {
+    isCancelled,
+    now: options.now,
+    timeSliceMs: options.chunkBudgetMs,
+    yieldToEventLoop: options.yieldToEventLoop,
+  });
+  return job.rasterTile;
+}

--- a/packages/cli/src/tile-renderer.ts
+++ b/packages/cli/src/tile-renderer.ts
@@ -1,0 +1,360 @@
+import { inspectBackingBuffers } from "@osmix/shared/backing-buffers";
+import { GenerationGate } from "@osmix/shared/generation-gate";
+import type { ShortbreadFeatureIndexTransferables } from "@osmix/shortbread";
+import type { Remote } from "comlink";
+import {
+  getOsmixCapabilities,
+  type OsmInfo,
+  OsmixRemote,
+  selectWorkerCount,
+  type OsmTransferables,
+  type Tile,
+} from "osmix";
+
+import type { MapLabelCandidate } from "./map-labels.ts";
+import type { TileImage } from "./map-pixels.ts";
+import type { SemanticNodeIndexTransferables } from "./semantic-node-index.ts";
+import type { SemanticRenderIndexTransferables } from "./semantic-render-index.ts";
+import type { MapLabelQueryRequest, MapLabelQueryResult, CliTileWorker } from "./tile-worker.ts";
+
+const MAX_CLI_WORKERS = 4;
+const WORKER_RPC_TIMEOUT_MS = 60_000;
+const DATASET_LOAD_TIMEOUT_MS = 10 * 60_000;
+
+export type TileRenderingMode = "workers";
+
+export interface BackingBufferDiagnostics {
+  allShared: boolean;
+  referenceCount: number;
+  uniqueCount: number;
+}
+
+export interface StyledTileRendererDiagnostics {
+  datasetBuffers: BackingBufferDiagnostics;
+  restartCount: number;
+  semanticIndexBuffers: BackingBufferDiagnostics;
+  tileWorkerCount: number;
+  totalWorkerCount: number;
+}
+
+export interface StyledTileRenderer {
+  readonly labelsConcurrent: boolean;
+  readonly mode: TileRenderingMode;
+  /** Number of workers available for concurrent raster tile jobs. */
+  readonly workerCount: number;
+  cancelBefore(generation: number): void;
+  diagnostics(): StyledTileRendererDiagnostics;
+  dispose(): void;
+  loadPbfFile(filePath: string, id: string): Promise<OsmInfo>;
+  queryLabels(request: MapLabelQueryRequest): Promise<{
+    candidates: MapLabelCandidate[];
+    revision: number;
+  }>;
+  renderTile(tile: Tile, generation: number): Promise<TileImage | null>;
+}
+
+interface StyledTileRendererOptions {
+  onProgress?: (message: string) => void;
+}
+
+interface LoadSource {
+  filePath: string;
+  id: string;
+}
+
+function backingBufferDiagnostics(value: unknown): BackingBufferDiagnostics {
+  const inspection = inspectBackingBuffers(value);
+  return {
+    allShared: inspection.unique > 0 && inspection.shared === inspection.unique,
+    referenceCount: inspection.references,
+    uniqueCount: inspection.unique,
+  };
+}
+
+export function tileWorkerUrl(moduleUrl: string | URL = import.meta.url): URL {
+  const extension = new URL(moduleUrl).pathname.endsWith(".ts") ? "ts" : "js";
+  return new URL(`./cli.worker.${extension}`, moduleUrl);
+}
+
+/** Reserve one logical core for OpenTUI and cap the worker set at four. */
+export function selectTileWorkerCount(hardwareConcurrency: number): number {
+  return selectWorkerCount({ hardwareConcurrency, reserveCores: 1, maxWorkers: MAX_CLI_WORKERS });
+}
+
+/** CLI-specific state layered on the shared Osmix worker scheduler. */
+class CliStyledTileRemote extends OsmixRemote<CliTileWorker> {
+  private readonly canShareArrayBuffers: boolean;
+  private datasetBuffers: OsmTransferables | null = null;
+  private datasetInfo: OsmInfo | null = null;
+  private disposed = false;
+  private readonly generationGate: GenerationGate;
+  private loadSource: LoadSource | null = null;
+  private nodeIndexBuffers: SemanticNodeIndexTransferables | null = null;
+  private readonly progressReporter: ((message: string) => void) | undefined;
+  private renderIndexBuffers: SemanticRenderIndexTransferables | null = null;
+  private shortbreadIndexBuffers: ShortbreadFeatureIndexTransferables | null = null;
+
+  constructor(canShareArrayBuffers: boolean, onProgress?: (message: string) => void) {
+    super();
+    this.canShareArrayBuffers = canShareArrayBuffers;
+    this.generationGate = GenerationGate.create({ shared: canShareArrayBuffers });
+    this.progressReporter = onProgress;
+  }
+
+  get labelsConcurrent(): boolean {
+    return this.workerCount > 1;
+  }
+
+  get tileWorkerCount(): number {
+    if (this.workerCount === 0) return 0;
+    return this.workerCount > 1 ? this.workerCount - 1 : 1;
+  }
+
+  cancelBefore(generation: number): void {
+    if (this.disposed || generation <= this.generationGate.generation) return;
+    this.generationGate.update(generation);
+    if (this.generationGate.hasSharedState) return;
+    this.notifyWorkers((worker) => worker.cancelTilesBefore(generation), this.tileWorkerIndexes());
+  }
+
+  styledDiagnostics(): StyledTileRendererDiagnostics {
+    this.assertActive();
+    const pool = this.workerPoolDiagnostics();
+    return {
+      datasetBuffers: backingBufferDiagnostics(this.datasetBuffers),
+      restartCount: pool.restartCount,
+      semanticIndexBuffers: backingBufferDiagnostics([
+        this.shortbreadIndexBuffers,
+        this.nodeIndexBuffers,
+        this.renderIndexBuffers,
+      ]),
+      tileWorkerCount: this.tileWorkerCount,
+      totalWorkerCount: pool.workerCount,
+    };
+  }
+
+  disposeRenderer(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.terminate();
+    this.datasetBuffers = null;
+    this.datasetInfo = null;
+    this.loadSource = null;
+    this.nodeIndexBuffers = null;
+    this.renderIndexBuffers = null;
+    this.shortbreadIndexBuffers = null;
+  }
+
+  async loadPbfFile(filePath: string, id: string): Promise<OsmInfo> {
+    this.assertActive();
+    this.loadSource = { filePath, id };
+    this.datasetBuffers = null;
+    this.datasetInfo = null;
+    this.nodeIndexBuffers = null;
+    this.renderIndexBuffers = null;
+    this.shortbreadIndexBuffers = null;
+
+    const info = await this.runWithWorker(
+      (worker) => worker.fromPbfFile(filePath, { id, buildSpatialIndexes: ["way", "relation"] }),
+      {
+        lane: "control",
+        retry: "once",
+        timeoutMs: DATASET_LOAD_TIMEOUT_MS,
+      },
+    );
+    this.datasetInfo = info;
+    if (!this.canShareArrayBuffers) return info;
+
+    this.progressReporter?.("Sharing map indexes with tile workers…");
+    await this.runWithWorker(
+      async (control) => {
+        this.datasetBuffers = await control.getOsmBuffers(info.id);
+        this.shortbreadIndexBuffers = await control.getShortbreadFeatureIndexTransferables(info.id);
+        this.renderIndexBuffers = await control.getSemanticRenderIndexTransferables(info.id);
+        this.nodeIndexBuffers = await control.getSemanticNodeIndexTransferables(info.id);
+        await this.populateOtherWorkers(control, info.id);
+      },
+      { lane: "control", retry: "once", timeoutMs: WORKER_RPC_TIMEOUT_MS },
+    );
+
+    if (this.workerCount > 1) {
+      const contentHash = this.datasetBuffers!.contentHash;
+      await Promise.all(
+        this.tileWorkerIndexes().map((index) =>
+          this.runOnWorker(
+            index,
+            async (worker) => {
+              await worker.setShortbreadFeatureIndex(
+                info.id,
+                contentHash,
+                this.shortbreadIndexBuffers!,
+              );
+              await worker.setSemanticNodeIndex(info.id, contentHash, this.nodeIndexBuffers!);
+              await worker.setSemanticRenderIndex(info.id, contentHash, this.renderIndexBuffers!);
+            },
+            { retry: "once", timeoutMs: WORKER_RPC_TIMEOUT_MS },
+          ),
+        ),
+      );
+    }
+    return info;
+  }
+
+  queryLabels(request: MapLabelQueryRequest): Promise<MapLabelQueryResult> {
+    this.assertReady();
+    return this.runWithWorker(
+      (worker) => worker.getMapLabelCandidates(this.datasetInfo!.id, request),
+      { lane: "control", retry: "once", timeoutMs: WORKER_RPC_TIMEOUT_MS },
+    );
+  }
+
+  async renderTile(tile: Tile, generation: number): Promise<TileImage | null> {
+    this.assertReady();
+    if (this.generationGate.isCancelled(generation)) return null;
+    const cancellation = this.generationGate.transferables();
+    const data = await this.runWithWorker(
+      (worker) => {
+        if (this.generationGate.isCancelled(generation)) return null;
+        if (!this.generationGate.hasSharedState) {
+          return worker.getStyledRasterTileCooperatively(this.datasetInfo!.id, tile, generation);
+        }
+        return worker.getStyledRasterTile(this.datasetInfo!.id, tile, generation, cancellation);
+      },
+      { lane: "compute", retry: "once", timeoutMs: WORKER_RPC_TIMEOUT_MS },
+    );
+    return data ? { data } : null;
+  }
+
+  protected override async rehydrateWorker(
+    worker: Remote<CliTileWorker>,
+    index: number,
+  ): Promise<void> {
+    if (!this.datasetInfo || !this.loadSource) return;
+    this.progressReporter?.(`Restarting map worker ${index + 1}…`);
+
+    if (this.datasetBuffers) {
+      if (!(await worker.has(this.datasetInfo.id))) {
+        await worker.transferIn(this.datasetBuffers);
+      }
+      if (this.shortbreadIndexBuffers) {
+        await worker.setShortbreadFeatureIndex(
+          this.datasetInfo.id,
+          this.datasetBuffers.contentHash,
+          this.shortbreadIndexBuffers,
+        );
+      }
+      if (this.renderIndexBuffers) {
+        await worker.setSemanticRenderIndex(
+          this.datasetInfo.id,
+          this.datasetBuffers.contentHash,
+          this.renderIndexBuffers,
+        );
+      }
+      if (index === 0) {
+        await worker.buildSemanticNodeIndex(this.datasetInfo.id);
+        await worker.buildSemanticLabelIndex(this.datasetInfo.id);
+      } else if (this.nodeIndexBuffers) {
+        await worker.setSemanticNodeIndex(
+          this.datasetInfo.id,
+          this.datasetBuffers.contentHash,
+          this.nodeIndexBuffers,
+        );
+      }
+      await worker.cancelTilesBefore(this.generationGate.generation);
+      return;
+    }
+
+    if (index !== 0) throw Error("Unable to restore a CLI worker without a shared dataset");
+    this.progressReporter?.("Reloading the map after a worker restart…");
+    this.datasetInfo = await worker.fromPbfFile(this.loadSource.filePath, {
+      id: this.loadSource.id,
+      buildSpatialIndexes: ["way", "relation"],
+    });
+    await worker.cancelTilesBefore(this.generationGate.generation);
+  }
+
+  private assertActive(): void {
+    if (this.disposed) throw Error("Tile renderer disposed");
+  }
+
+  private assertReady(): void {
+    this.assertActive();
+    if (!this.datasetInfo) throw Error("No PBF dataset is loaded");
+  }
+
+  private tileWorkerIndexes(): readonly number[] {
+    const indexes = this.workerIndexes();
+    return indexes.length > 1 ? indexes.slice(1) : indexes;
+  }
+}
+
+class WorkerBackedStyledTileRenderer implements StyledTileRenderer {
+  readonly mode = "workers" as const;
+  private readonly remote: CliStyledTileRemote;
+
+  constructor(remote: CliStyledTileRemote) {
+    this.remote = remote;
+  }
+
+  get workerCount(): number {
+    return this.remote.tileWorkerCount;
+  }
+
+  get labelsConcurrent(): boolean {
+    return this.remote.labelsConcurrent;
+  }
+
+  cancelBefore(generation: number): void {
+    this.remote.cancelBefore(generation);
+  }
+
+  diagnostics(): StyledTileRendererDiagnostics {
+    return this.remote.styledDiagnostics();
+  }
+
+  dispose(): void {
+    this.remote.disposeRenderer();
+  }
+
+  loadPbfFile(filePath: string, id: string): Promise<OsmInfo> {
+    return this.remote.loadPbfFile(filePath, id);
+  }
+
+  queryLabels(request: MapLabelQueryRequest): Promise<MapLabelQueryResult> {
+    return this.remote.queryLabels(request);
+  }
+
+  renderTile(tile: Tile, generation: number): Promise<TileImage | null> {
+    return this.remote.renderTile(tile, generation);
+  }
+}
+
+/** Create the required off-main-thread CLI worker pool. */
+export async function createStyledTileRenderer(
+  options: StyledTileRendererOptions = {},
+): Promise<StyledTileRenderer> {
+  const capabilities = getOsmixCapabilities();
+  if (!capabilities.webWorkers) {
+    throw Error("The osmix viewer requires Web Worker support for non-blocking rendering.");
+  }
+  const count = capabilities.canShareArrayBuffers
+    ? selectTileWorkerCount(capabilities.hardwareConcurrency)
+    : 1;
+  const remote = new CliStyledTileRemote(capabilities.canShareArrayBuffers, options.onProgress);
+  try {
+    // The runtime adapter selects Bun's Web Worker API instead of its Node compatibility layer.
+    await remote.initializeWorkerPool(
+      count,
+      tileWorkerUrl(),
+      options.onProgress ? (progress) => options.onProgress?.(progress.msg) : undefined,
+      false,
+      1,
+      capabilities.workerRuntime,
+      DATASET_LOAD_TIMEOUT_MS,
+    );
+    return new WorkerBackedStyledTileRenderer(remote);
+  } catch (error) {
+    remote.disposeRenderer();
+    throw error;
+  }
+}

--- a/packages/cli/src/tile-worker.ts
+++ b/packages/cli/src/tile-worker.ts
@@ -1,0 +1,364 @@
+import { createReadStream } from "node:fs";
+import { Readable } from "node:stream";
+
+import { GenerationGate, type GenerationGateTransferables } from "@osmix/shared/generation-gate";
+import {
+  ShortbreadFeatureIndex,
+  type ShortbreadFeatureIndexTransferables,
+} from "@osmix/shortbread";
+import {
+  OsmixWorker,
+  progressEvent,
+  transfer,
+  type OsmFromPbfOptions,
+  type OsmTransferables,
+  type Tile,
+} from "osmix";
+
+import { MapCamera, type MapViewport } from "./camera.ts";
+import { collectMapLabelCandidates, type MapLabelCandidate } from "./map-labels.ts";
+import { SemanticLabelIndex } from "./semantic-label-index.ts";
+import { SemanticNodeIndex, type SemanticNodeIndexTransferables } from "./semantic-node-index.ts";
+import {
+  SemanticRenderIndex,
+  type SemanticRenderIndexTransferables,
+} from "./semantic-render-index.ts";
+import { drawStyledMapTile, drawStyledMapTileAsync } from "./styled-tile.ts";
+
+export interface MapLabelQueryRequest {
+  centerX: number;
+  centerY: number;
+  revision: number;
+  viewport: MapViewport;
+  zoom: number;
+}
+
+export interface MapLabelQueryResult {
+  candidates: MapLabelCandidate[];
+  revision: number;
+}
+
+interface CachedSemanticNodeIndex {
+  contentHash: string;
+  index: SemanticNodeIndex;
+}
+
+interface CachedSemanticLabelIndex {
+  contentHash: string;
+  index: SemanticLabelIndex;
+}
+
+interface CachedSemanticRenderIndex {
+  contentHash: string;
+  index: SemanticRenderIndex;
+}
+
+interface CachedShortbreadFeatureIndex {
+  contentHash: string;
+  index: ShortbreadFeatureIndex;
+}
+
+/** Osmix worker extension for the CLI's private semantic raster style. */
+export class CliTileWorker extends OsmixWorker {
+  private readonly tileGenerationGate = GenerationGate.create({ shared: false });
+  private readonly semanticLabelIndexes = new Map<string, CachedSemanticLabelIndex>();
+  private readonly semanticNodeIndexes = new Map<string, CachedSemanticNodeIndex>();
+  private readonly semanticRenderIndexes = new Map<string, CachedSemanticRenderIndex>();
+  private readonly shortbreadFeatureIndexes = new Map<string, CachedShortbreadFeatureIndex>();
+
+  async fromPbfFile(filePath: string, options: Partial<OsmFromPbfOptions> = {}) {
+    const stream = createReadStream(filePath);
+    try {
+      const info = await this.fromPbf({
+        data: Readable.toWeb(stream) as ReadableStream<Uint8Array>,
+        options,
+      });
+      this.semanticLabelIndexes.delete(info.id);
+      this.semanticNodeIndexes.delete(info.id);
+      this.semanticRenderIndexes.delete(info.id);
+      this.shortbreadFeatureIndexes.delete(info.id);
+      this.buildShortbreadFeatureIndex(info.id, true);
+      this.buildSemanticNodeIndex(info.id, true);
+      this.buildSemanticLabelIndex(info.id, true);
+      this.buildSemanticRenderIndex(info.id, true);
+      return info;
+    } finally {
+      stream.destroy();
+    }
+  }
+
+  override transferIn(transferables: OsmTransferables): void {
+    const cachedFeatures = this.shortbreadFeatureIndexes.get(transferables.id);
+    if (cachedFeatures?.contentHash !== transferables.contentHash) {
+      this.shortbreadFeatureIndexes.delete(transferables.id);
+    }
+    const cachedLabels = this.semanticLabelIndexes.get(transferables.id);
+    if (cachedLabels?.contentHash !== transferables.contentHash) {
+      this.semanticLabelIndexes.delete(transferables.id);
+    }
+    const cached = this.semanticNodeIndexes.get(transferables.id);
+    if (cached?.contentHash !== transferables.contentHash) {
+      this.semanticNodeIndexes.delete(transferables.id);
+    }
+    const cachedRender = this.semanticRenderIndexes.get(transferables.id);
+    if (cachedRender?.contentHash !== transferables.contentHash) {
+      this.semanticRenderIndexes.delete(transferables.id);
+    }
+    super.transferIn(transferables);
+  }
+
+  override delete(id: string): void {
+    this.semanticLabelIndexes.delete(id);
+    this.semanticNodeIndexes.delete(id);
+    this.semanticRenderIndexes.delete(id);
+    this.shortbreadFeatureIndexes.delete(id);
+    super.delete(id);
+  }
+
+  buildShortbreadFeatureIndex(id: string, reportProgress = false): { features: number } {
+    if (reportProgress) this.dispatchEvent(progressEvent("Indexing Shortbread map features..."));
+    const osm = this.get(id);
+    const index = ShortbreadFeatureIndex.build(osm);
+    this.shortbreadFeatureIndexes.set(id, { contentHash: osm.contentHash(), index });
+    if (reportProgress) {
+      this.dispatchEvent(
+        progressEvent(`Indexed ${index.size.toLocaleString()} classified map features.`),
+      );
+    }
+    return { features: index.size };
+  }
+
+  buildSemanticNodeIndex(id: string, reportProgress = false): { labels: number; nodes: number } {
+    if (reportProgress) this.dispatchEvent(progressEvent("Indexing semantic map points..."));
+    const osm = this.get(id);
+    const index = SemanticNodeIndex.build(osm, this.getShortbreadFeatureIndex(id));
+    this.semanticNodeIndexes.set(id, { contentHash: osm.contentHash(), index });
+    if (reportProgress) {
+      this.dispatchEvent(
+        progressEvent(
+          `Indexed ${index.size.toLocaleString()} semantic map points for terminal rendering.`,
+        ),
+      );
+    }
+    return { labels: index.labelCount, nodes: index.size };
+  }
+
+  buildSemanticLabelIndex(id: string, reportProgress = false): { relations: number; ways: number } {
+    if (reportProgress) this.dispatchEvent(progressEvent("Indexing semantic map labels..."));
+    const osm = this.get(id);
+    const index = SemanticLabelIndex.build(osm, this.getShortbreadFeatureIndex(id));
+    this.semanticLabelIndexes.set(id, { contentHash: osm.contentHash(), index });
+    if (reportProgress) {
+      this.dispatchEvent(
+        progressEvent(
+          `Indexed ${(index.wayCount + index.relationCount).toLocaleString()} semantic map labels.`,
+        ),
+      );
+    }
+    return { relations: index.relationCount, ways: index.wayCount };
+  }
+
+  buildSemanticRenderIndex(
+    id: string,
+    reportProgress = false,
+  ): { relations: number; ways: number } {
+    if (reportProgress) this.dispatchEvent(progressEvent("Indexing semantic map geometry..."));
+    const osm = this.get(id);
+    const index = SemanticRenderIndex.build(osm, this.getShortbreadFeatureIndex(id));
+    this.semanticRenderIndexes.set(id, { contentHash: osm.contentHash(), index });
+    if (reportProgress) {
+      this.dispatchEvent(
+        progressEvent(
+          `Indexed ${(index.wayCount + index.relationCount).toLocaleString()} semantic map features.`,
+        ),
+      );
+    }
+    return { relations: index.relationCount, ways: index.wayCount };
+  }
+
+  getSemanticNodeIndexTransferables(id: string): SemanticNodeIndexTransferables {
+    return this.getSemanticNodeIndex(id).transferables();
+  }
+
+  getShortbreadFeatureIndexTransferables(id: string): ShortbreadFeatureIndexTransferables {
+    return this.getShortbreadFeatureIndex(id).transferables();
+  }
+
+  setShortbreadFeatureIndex(
+    id: string,
+    contentHash: string,
+    transferables: ShortbreadFeatureIndexTransferables,
+  ): void {
+    if (this.get(id).contentHash() !== contentHash) {
+      throw Error(`Shortbread feature index content mismatch for id: ${id}`);
+    }
+    this.shortbreadFeatureIndexes.set(id, {
+      contentHash,
+      index: ShortbreadFeatureIndex.fromTransferables(transferables),
+    });
+  }
+
+  setSemanticNodeIndex(
+    id: string,
+    contentHash: string,
+    transferables: SemanticNodeIndexTransferables,
+  ): void {
+    if (this.get(id).contentHash() !== contentHash) {
+      throw Error(`Semantic node index content mismatch for id: ${id}`);
+    }
+    this.installShortbreadFeatureIndex(id, contentHash, transferables.featureIndex);
+    this.semanticNodeIndexes.set(id, {
+      contentHash,
+      index: SemanticNodeIndex.fromTransferables(transferables, this.getShortbreadFeatureIndex(id)),
+    });
+  }
+
+  getSemanticRenderIndexTransferables(id: string): SemanticRenderIndexTransferables {
+    return this.getSemanticRenderIndex(id).transferables();
+  }
+
+  setSemanticRenderIndex(
+    id: string,
+    contentHash: string,
+    transferables: SemanticRenderIndexTransferables,
+  ): void {
+    if (this.get(id).contentHash() !== contentHash) {
+      throw Error(`Semantic render index content mismatch for id: ${id}`);
+    }
+    this.installShortbreadFeatureIndex(id, contentHash, transferables.featureIndex);
+    this.semanticRenderIndexes.set(id, {
+      contentHash,
+      index: SemanticRenderIndex.fromTransferables(
+        transferables,
+        this.getShortbreadFeatureIndex(id),
+      ),
+    });
+  }
+
+  getMapLabelCandidates(id: string, request: MapLabelQueryRequest): MapLabelQueryResult {
+    const camera = new MapCamera(request.centerX, request.centerY, request.zoom);
+    const index = this.getSemanticNodeIndex(id);
+    const nodes = index.findLabelNodes(camera.visibleBboxes(request.viewport), camera.zoom);
+    const providers = this.getSemanticLabelIndex(id).providers(camera.zoom);
+    return {
+      candidates: collectMapLabelCandidates(this.get(id), camera, request.viewport, {
+        nodes,
+        ...providers,
+      }),
+      revision: request.revision,
+    };
+  }
+
+  /** Receive cooperative cancellation updates while an asynchronous tile job is yielded. */
+  cancelTilesBefore(generation: number): void {
+    this.tileGenerationGate.update(generation);
+  }
+
+  getStyledRasterTile(
+    id: string,
+    tile: Tile,
+    generation = 0,
+    cancellationState?: GenerationGateTransferables,
+  ): Uint8ClampedArray | null {
+    const osm = this.get(id);
+    const renderIndex = this.getSemanticRenderIndex(id);
+    const nodeIndex = tile[2] >= 14 ? this.getSemanticNodeIndex(id) : undefined;
+    const cancellation = cancellationState
+      ? GenerationGate.fromTransferables(cancellationState)
+      : null;
+    const isCancelled = () => cancellation?.isCancelled(generation) ?? false;
+    if (isCancelled()) return null;
+    const imageData = drawStyledMapTile(
+      osm,
+      tile,
+      256,
+      nodeIndex,
+      {
+        relations: renderIndex.relations(osm.relations, tile[2]),
+        ways: renderIndex.ways(osm.ways, tile[2]),
+      },
+      isCancelled,
+    ).imageData;
+    return isCancelled() ? null : transfer(imageData);
+  }
+
+  /** Render without SharedArrayBuffer while yielding often enough to service cancel RPCs. */
+  async getStyledRasterTileCooperatively(
+    id: string,
+    tile: Tile,
+    generation = 0,
+  ): Promise<Uint8ClampedArray | null> {
+    const isCancelled = () => this.tileGenerationGate.isCancelled(generation);
+    if (isCancelled()) return null;
+    const osm = this.get(id);
+    const renderIndex = this.getSemanticRenderIndex(id);
+    const nodeIndex = tile[2] >= 14 ? this.getSemanticNodeIndex(id) : undefined;
+    const imageData = (
+      await drawStyledMapTileAsync(
+        osm,
+        tile,
+        256,
+        nodeIndex,
+        {
+          relations: renderIndex.relations(osm.relations, tile[2]),
+          ways: renderIndex.ways(osm.ways, tile[2]),
+        },
+        isCancelled,
+      )
+    ).imageData;
+    return isCancelled() ? null : transfer(imageData);
+  }
+
+  private getSemanticNodeIndex(id: string): SemanticNodeIndex {
+    let cached = this.semanticNodeIndexes.get(id);
+    if (!cached || cached.contentHash !== this.get(id).contentHash()) {
+      this.buildSemanticNodeIndex(id);
+      cached = this.semanticNodeIndexes.get(id);
+    }
+    if (!cached) throw Error(`Semantic node index not found for id: ${id}`);
+    return cached.index;
+  }
+
+  private getSemanticLabelIndex(id: string): SemanticLabelIndex {
+    let cached = this.semanticLabelIndexes.get(id);
+    if (!cached || cached.contentHash !== this.get(id).contentHash()) {
+      this.buildSemanticLabelIndex(id);
+      cached = this.semanticLabelIndexes.get(id);
+    }
+    if (!cached) throw Error(`Semantic label index not found for id: ${id}`);
+    return cached.index;
+  }
+
+  private getSemanticRenderIndex(id: string): SemanticRenderIndex {
+    let cached = this.semanticRenderIndexes.get(id);
+    if (!cached || cached.contentHash !== this.get(id).contentHash()) {
+      this.buildSemanticRenderIndex(id);
+      cached = this.semanticRenderIndexes.get(id);
+    }
+    if (!cached) throw Error(`Semantic render index not found for id: ${id}`);
+    return cached.index;
+  }
+
+  private getShortbreadFeatureIndex(id: string): ShortbreadFeatureIndex {
+    let cached = this.shortbreadFeatureIndexes.get(id);
+    if (!cached || cached.contentHash !== this.get(id).contentHash()) {
+      this.buildShortbreadFeatureIndex(id);
+      cached = this.shortbreadFeatureIndexes.get(id);
+    }
+    if (!cached) throw Error(`Shortbread feature index not found for id: ${id}`);
+    return cached.index;
+  }
+
+  private installShortbreadFeatureIndex(
+    id: string,
+    contentHash: string,
+    transferables: ShortbreadFeatureIndexTransferables,
+  ): void {
+    const cached = this.shortbreadFeatureIndexes.get(id);
+    if (cached?.contentHash === contentHash) return;
+    this.shortbreadFeatureIndexes.set(id, {
+      contentHash,
+      index: ShortbreadFeatureIndex.fromTransferables(transferables),
+    });
+  }
+}

--- a/packages/cli/src/viewer.ts
+++ b/packages/cli/src/viewer.ts
@@ -1,0 +1,588 @@
+import { basename, resolve } from "node:path";
+
+import {
+  createCliRenderer,
+  FrameBufferRenderable,
+  MouseButton,
+  RGBA,
+  type KeyEvent,
+  type MouseEvent,
+  type OptimizedBuffer,
+} from "@opentui/core";
+import { type GeoBbox2D, type OsmInfo } from "osmix";
+
+import { MapCamera, type MapViewport } from "./camera.ts";
+import {
+  layoutMapLabels,
+  truncateLabelText,
+  type MapLabelCandidate,
+  type MapLabelKind,
+  type MeasuredLabelText,
+  type PlacedMapLabel,
+} from "./map-labels.ts";
+import {
+  formatTileLoadingStatus,
+  isShimmerCell,
+  MAP_BACKGROUND,
+  OsmTileLoader,
+  type PendingTileRegion,
+  renderMapPixels,
+  TILE_LOADING_HIGHLIGHT,
+} from "./map-pixels.ts";
+import {
+  createStyledTileRenderer,
+  type StyledTileRenderer,
+  type TileRenderingMode,
+} from "./tile-renderer.ts";
+
+const BACKGROUND = RGBA.fromInts(...MAP_BACKGROUND, 255);
+const STATUS_BACKGROUND = RGBA.fromHex("#173c2c");
+const STATUS_FOREGROUND = RGBA.fromHex("#d6f5df");
+const ERROR_FOREGROUND = RGBA.fromHex("#ffb4ab");
+const LABEL_BACKGROUND = RGBA.fromHex("#101713");
+const SHIMMER_HIGHLIGHT = RGBA.fromInts(...TILE_LOADING_HIGHLIGHT, 255);
+const LABEL_COLORS = {
+  place: RGBA.fromHex("#f2ead3"),
+  road: RGBA.fromHex("#d6ded8"),
+  water: RGBA.fromHex("#9bcbe4"),
+  site: RGBA.fromHex("#b6d5b8"),
+  poi: RGBA.fromHex("#efd0a8"),
+} satisfies Record<MapLabelKind, RGBA>;
+const HALF_BLOCK = "▀";
+const ANIMATION_INTERVAL_MS = 100;
+const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"] as const;
+
+type ViewerRenderer = Awaited<ReturnType<typeof createCliRenderer>>;
+
+interface ViewerTestHooks {
+  onStaticCompose?: () => void;
+}
+
+type ViewerState =
+  | { kind: "loading"; message: string }
+  | {
+      info: OsmInfo;
+      kind: "ready";
+      tileRenderer: StyledTileRenderer;
+      tiles: OsmTileLoader;
+    }
+  | { kind: "error"; message: string };
+
+function isValidBounds(bounds: GeoBbox2D): boolean {
+  return bounds.every(Number.isFinite) && bounds[0] <= bounds[2] && bounds[1] <= bounds[3];
+}
+
+function truncate(text: string, width: number): string {
+  if (text.length <= width) return text;
+  if (width <= 1) return text.slice(0, width);
+  return `${text.slice(0, width - 1)}…`;
+}
+
+export function animationPhase(now = performance.now()): number {
+  return Math.floor(now / ANIMATION_INTERVAL_MS);
+}
+
+export function viewerShouldAnimate(
+  stateKind: ViewerState["kind"],
+  pendingCount: number,
+  labelsPending = false,
+): boolean {
+  return stateKind === "loading" || (stateKind === "ready" && (pendingCount > 0 || labelsPending));
+}
+
+export function formatRenderingModeStatus(_mode: TileRenderingMode): string {
+  return "";
+}
+
+/** Interactive viewer whose OpenTUI thread only composes prepared pixels and text. */
+export class TerminalMapViewer {
+  readonly renderer: ViewerRenderer;
+  readonly canvas: FrameBufferRenderable;
+  readonly fileName: string;
+  readonly colors = new Map<number, RGBA>();
+  camera = new MapCamera();
+  state: ViewerState = { kind: "loading", message: "Opening file…" };
+  dataBounds: GeoBbox2D | null = null;
+  dragPoint: { x: number; y: number } | null = null;
+
+  private animationLive = false;
+  private animationTimer: ReturnType<typeof setInterval> | null = null;
+  private cleanedUp = false;
+  private labelCandidates: MapLabelCandidate[] = [];
+  private labelLayoutDirty = false;
+  private labelQueryActive = false;
+  private labelQueryQueued: number | null = null;
+  private labels: PlacedMapLabel[] = [];
+  private pendingRegions: PendingTileRegion[] = [];
+  private staticDirty = true;
+  private readonly testHooks: ViewerTestHooks;
+  private viewportRevision = 0;
+  private readonly now: () => number;
+
+  private readonly frameCallback = async (): Promise<void> => {
+    if (this.renderer.isDestroyed) return;
+    if (this.staticDirty) this.composeStaticFrame();
+    this.pumpLabelQuery();
+  };
+
+  private readonly postProcess = (buffer: OptimizedBuffer): void => {
+    if (this.renderer.isDestroyed) return;
+    this.drawDynamicOverlay(buffer, animationPhase(this.now()));
+  };
+
+  constructor(
+    renderer: ViewerRenderer,
+    fileName: string,
+    now: () => number = () => performance.now(),
+    testHooks: ViewerTestHooks = {},
+  ) {
+    this.renderer = renderer;
+    this.fileName = fileName;
+    this.now = now;
+    this.testHooks = testHooks;
+    this.canvas = new FrameBufferRenderable(renderer, {
+      id: "osm-map",
+      width: renderer.width,
+      height: renderer.height,
+      onMouseDown: (event) => this.handleMouseDown(event),
+      onMouseUp: () => {
+        this.dragPoint = null;
+      },
+      onMouseDrag: (event) => this.handleMouseDrag(event),
+      onMouseDragEnd: () => {
+        this.dragPoint = null;
+      },
+      onMouseScroll: (event) => this.handleMouseScroll(event),
+      onSizeChange: () => queueMicrotask(() => this.invalidateViewport()),
+    });
+    this.renderer.root.add(this.canvas);
+    this.renderer.keyInput.on("keypress", (key: KeyEvent) => this.handleKey(key));
+    this.renderer.on("resize", (width, height) => {
+      this.canvas.width = width;
+      this.canvas.height = height;
+    });
+    this.renderer.setFrameCallback(this.frameCallback);
+    this.renderer.addPostProcessFn(this.postProcess);
+    this.renderer.once("destroy", () => this.cleanup());
+    this.renderer.setTerminalTitle(`osmix — ${fileName}`);
+    this.requestStaticFrame();
+    this.updateAnimationState();
+  }
+
+  static async create(fileName: string): Promise<TerminalMapViewer> {
+    const renderer = await createCliRenderer({
+      screenMode: "alternate-screen",
+      consoleMode: "console-overlay",
+      openConsoleOnError: false,
+      exitOnCtrlC: true,
+      useMouse: true,
+      enableMouseMovement: true,
+      autoFocus: false,
+      backgroundColor: BACKGROUND,
+      targetFps: 10,
+      maxFps: 30,
+    });
+    return new TerminalMapViewer(renderer, fileName);
+  }
+
+  setProgress(message: string): void {
+    if (this.renderer.isDestroyed) return;
+    if (this.state.kind !== "loading") return;
+    this.state = { kind: "loading", message };
+    this.canvas.requestRender();
+    this.updateAnimationState();
+  }
+
+  setLoadingMessage(message: string): void {
+    this.setProgress(message);
+  }
+
+  setDataset(info: OsmInfo, tileRenderer: StyledTileRenderer): void {
+    if (!isValidBounds(info.bbox)) throw Error("The PBF contains no nodes to display.");
+    this.dataBounds = info.bbox;
+    const tiles = new OsmTileLoader({
+      maxConcurrentTiles: tileRenderer.workerCount,
+      onError: (error) => this.setError(error),
+      onGenerationChange: (generation) => tileRenderer.cancelBefore(generation),
+      onPendingChange: () => {
+        this.canvas.requestRender();
+        this.updateAnimationState();
+      },
+      onTileComplete: () => this.requestStaticFrame(),
+      renderTile: (tile, generation) => tileRenderer.renderTile(tile, generation),
+    });
+    this.state = { kind: "ready", info, tileRenderer, tiles };
+    this.fitBounds();
+  }
+
+  setError(error: unknown): void {
+    if (this.renderer.isDestroyed) return;
+    if (this.state.kind === "ready") {
+      this.state.tiles.dispose();
+      this.state.tileRenderer.dispose();
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    this.state = { kind: "error", message };
+    this.pendingRegions = [];
+    this.labelCandidates = [];
+    this.labels = [];
+    this.labelQueryActive = false;
+    this.labelQueryQueued = null;
+    this.requestStaticFrame();
+    this.updateAnimationState();
+  }
+
+  waitUntilClosed(): Promise<void> {
+    if (this.renderer.isDestroyed) return Promise.resolve();
+    return new Promise((resolve) => this.renderer.once("destroy", resolve));
+  }
+
+  private viewport(): MapViewport {
+    return {
+      width: this.canvas.frameBuffer.width,
+      height: Math.max(0, (this.canvas.frameBuffer.height - 1) * 2),
+    };
+  }
+
+  private fitBounds(): void {
+    if (!this.dataBounds || this.state.kind !== "ready") return;
+    this.camera = MapCamera.fitBounds(this.dataBounds, this.viewport());
+    this.invalidateViewport();
+  }
+
+  private handleKey(key: KeyEvent): void {
+    if (key.name === "q" || key.name === "escape") {
+      this.cleanup();
+      this.renderer.destroy();
+      return;
+    }
+    if (this.state.kind !== "ready") return;
+
+    const viewport = this.viewport();
+    const panX = Math.max(1, Math.floor(viewport.width / 4));
+    const panY = Math.max(1, Math.floor(viewport.height / 4));
+    switch (key.name) {
+      case "left":
+      case "h":
+        this.camera.panPixels(-panX, 0);
+        break;
+      case "right":
+      case "l":
+        this.camera.panPixels(panX, 0);
+        break;
+      case "up":
+      case "k":
+        this.camera.panPixels(0, -panY);
+        break;
+      case "down":
+      case "j":
+        this.camera.panPixels(0, panY);
+        break;
+      case "+":
+      case "=":
+      case "kpplus":
+        this.camera.zoomBy(1, viewport);
+        break;
+      case "-":
+      case "kpminus":
+        this.camera.zoomBy(-1, viewport);
+        break;
+      case "0":
+      case "kp0":
+        this.fitBounds();
+        return;
+      default:
+        return;
+    }
+    this.invalidateViewport();
+  }
+
+  private handleMouseDown(event: MouseEvent): void {
+    if (event.button !== MouseButton.LEFT || event.y >= this.canvas.frameBuffer.height - 1) return;
+    event.preventDefault();
+    this.dragPoint = { x: event.x, y: event.y };
+  }
+
+  private handleMouseDrag(event: MouseEvent): void {
+    if (this.state.kind !== "ready" || !this.dragPoint) return;
+    const deltaX = event.x - this.dragPoint.x;
+    const deltaY = event.y - this.dragPoint.y;
+    this.dragPoint = { x: event.x, y: event.y };
+    this.camera.panPixels(-deltaX, -deltaY * 2);
+    event.preventDefault();
+    event.stopPropagation();
+    this.invalidateViewport();
+  }
+
+  private handleMouseScroll(event: MouseEvent): void {
+    if (this.state.kind !== "ready" || !event.scroll) return;
+    if (event.scroll.direction !== "up" && event.scroll.direction !== "down") return;
+    const viewport = this.viewport();
+    this.camera.zoomBy(event.scroll.direction === "up" ? 1 : -1, viewport, {
+      x: event.x,
+      y: Math.min(viewport.height, event.y * 2 + 1),
+    });
+    event.preventDefault();
+    event.stopPropagation();
+    this.invalidateViewport();
+  }
+
+  private color(pixels: Uint8ClampedArray, offset: number): RGBA {
+    const red = pixels[offset]!;
+    const green = pixels[offset + 1]!;
+    const blue = pixels[offset + 2]!;
+    const key = (red << 16) | (green << 8) | blue;
+    let color = this.colors.get(key);
+    if (!color) {
+      color = RGBA.fromInts(red, green, blue, 255);
+      this.colors.set(key, color);
+    }
+    return color;
+  }
+
+  private cleanup(): void {
+    if (this.cleanedUp) return;
+    this.cleanedUp = true;
+    if (this.state.kind === "ready") {
+      this.state.tiles.dispose();
+      this.state.tileRenderer.dispose();
+    }
+    this.renderer.removeFrameCallback(this.frameCallback);
+    this.renderer.removePostProcessFn(this.postProcess);
+    if (this.animationTimer) clearInterval(this.animationTimer);
+    this.animationTimer = null;
+    if (this.animationLive && !this.renderer.isDestroyed) this.renderer.dropLive();
+    this.animationLive = false;
+  }
+
+  private updateAnimationState(): void {
+    if (this.renderer.isDestroyed) return;
+    const pendingCount = this.state.kind === "ready" ? this.state.tiles.pendingCount : 0;
+    const shouldAnimate = viewerShouldAnimate(
+      this.state.kind,
+      pendingCount,
+      this.labelQueryActive || this.labelQueryQueued !== null,
+    );
+    if (shouldAnimate && !this.animationLive) {
+      this.animationLive = true;
+      this.renderer.requestLive();
+      this.animationTimer = setInterval(() => {
+        if (!this.renderer.isDestroyed) this.canvas.requestRender();
+      }, ANIMATION_INTERVAL_MS);
+    } else if (!shouldAnimate && this.animationLive) {
+      this.animationLive = false;
+      if (this.animationTimer) clearInterval(this.animationTimer);
+      this.animationTimer = null;
+      this.renderer.dropLive();
+      this.canvas.requestRender();
+    }
+  }
+
+  private invalidateViewport(): void {
+    if (this.renderer.isDestroyed) return;
+    this.viewportRevision++;
+    this.labelCandidates = [];
+    this.labels = [];
+    this.labelLayoutDirty = false;
+    if (this.state.kind === "ready") this.labelQueryQueued = this.viewportRevision;
+    this.requestStaticFrame();
+  }
+
+  private requestStaticFrame(): void {
+    if (this.renderer.isDestroyed) return;
+    this.staticDirty = true;
+    this.canvas.requestRender();
+  }
+
+  private composeStaticFrame(): void {
+    this.testHooks.onStaticCompose?.();
+    this.staticDirty = false;
+    const buffer = this.canvas.frameBuffer;
+    const width = buffer.width;
+    const height = buffer.height;
+    if (width === 0 || height === 0) return;
+    const mapRows = Math.max(0, height - 1);
+    this.pendingRegions = [];
+    if (this.state.kind !== "ready" || mapRows === 0) {
+      buffer.fillRect(0, 0, width, mapRows, BACKGROUND);
+    } else {
+      const pixelHeight = mapRows * 2;
+      this.state.tiles.beginFrame(this.viewportRevision);
+      const pixels = renderMapPixels(
+        this.camera,
+        { width, height: pixelHeight },
+        this.state.tiles.getTile,
+        this.pendingRegions,
+      );
+      this.state.tiles.endFrame();
+      for (let row = 0; row < mapRows; row++) {
+        for (let column = 0; column < width; column++) {
+          const topOffset = (row * 2 * width + column) * 4;
+          const bottomOffset = ((row * 2 + 1) * width + column) * 4;
+          buffer.setCell(
+            column,
+            row,
+            HALF_BLOCK,
+            this.color(pixels, topOffset),
+            this.color(pixels, bottomOffset),
+          );
+        }
+      }
+    }
+    buffer.fillRect(0, mapRows, width, 1, STATUS_BACKGROUND);
+    this.updateAnimationState();
+  }
+
+  private pumpLabelQuery(): void {
+    if (this.labelQueryActive || this.labelQueryQueued === null || this.state.kind !== "ready")
+      return;
+    if (!this.state.tileRenderer.labelsConcurrent && this.state.tiles.pendingCount > 0) return;
+
+    const revision = this.labelQueryQueued;
+    this.labelQueryQueued = null;
+    const request = {
+      centerX: this.camera.centerX,
+      centerY: this.camera.centerY,
+      revision,
+      viewport: this.viewport(),
+      zoom: this.camera.zoom,
+    };
+    const tileRenderer = this.state.tileRenderer;
+    this.labelQueryActive = true;
+    this.updateAnimationState();
+    void tileRenderer
+      .queryLabels(request)
+      .then((result) => {
+        if (
+          this.renderer.isDestroyed ||
+          this.state.kind !== "ready" ||
+          result.revision !== this.viewportRevision
+        )
+          return;
+        this.labelCandidates = result.candidates;
+        this.labelLayoutDirty = true;
+        this.canvas.requestRender();
+      })
+      .catch((error: unknown) => this.setError(error))
+      .finally(() => {
+        this.labelQueryActive = false;
+        if (this.labelQueryQueued !== null) this.canvas.requestRender();
+        this.updateAnimationState();
+      });
+  }
+
+  private measureLabelText(
+    buffer: OptimizedBuffer,
+    text: string,
+    maxWidth: number,
+  ): MeasuredLabelText | null {
+    const encoded = buffer.encodeUnicode(text);
+    if (!encoded) return null;
+    try {
+      return truncateLabelText(
+        text,
+        encoded.data.map((character) => character.width),
+        maxWidth,
+      );
+    } finally {
+      buffer.freeUnicode(encoded);
+    }
+  }
+
+  private layoutLabels(buffer: OptimizedBuffer, width: number, mapRows: number): void {
+    if (!this.labelLayoutDirty) return;
+    this.labelLayoutDirty = false;
+    this.labels = layoutMapLabels(
+      this.labelCandidates,
+      { width, height: mapRows },
+      (text, maxWidth) => this.measureLabelText(buffer, text, maxWidth),
+    );
+  }
+
+  private drawDynamicOverlay(buffer: OptimizedBuffer, phase: number): void {
+    const width = buffer.width;
+    const height = buffer.height;
+    if (width === 0 || height === 0) return;
+    const mapRows = Math.max(0, height - 1);
+
+    for (const region of this.pendingRegions) {
+      const startX = Math.max(0, Math.floor(region.left));
+      const endX = Math.min(width, Math.ceil(region.right));
+      const startRow = Math.max(0, Math.floor(region.top / 2));
+      const endRow = Math.min(mapRows, Math.ceil(region.bottom / 2));
+      for (let row = startRow; row < endRow; row++) {
+        for (let column = startX; column < endX; column++) {
+          if (isShimmerCell(column, row, phase)) {
+            buffer.fillRect(column, row, 1, 1, SHIMMER_HIGHLIGHT);
+          }
+        }
+      }
+    }
+
+    this.layoutLabels(buffer, width, mapRows);
+    for (const label of this.labels) {
+      buffer.fillRect(label.backplateX, label.y, label.backplateWidth, 1, LABEL_BACKGROUND);
+      buffer.drawText(label.text, label.x, label.y, LABEL_COLORS[label.kind], LABEL_BACKGROUND);
+    }
+
+    buffer.fillRect(0, mapRows, width, 1, STATUS_BACKGROUND);
+    buffer.drawText(
+      truncate(this.statusText(phase), width),
+      0,
+      mapRows,
+      this.state.kind === "error" ? ERROR_FOREGROUND : STATUS_FOREGROUND,
+      STATUS_BACKGROUND,
+    );
+  }
+
+  private statusText(phase: number): string {
+    const spinner = SPINNER_FRAMES[phase % SPINNER_FRAMES.length]!;
+    if (this.state.kind === "loading") return `${this.fileName}  ${spinner} ${this.state.message}`;
+    if (this.state.kind === "error") return `Error: ${this.state.message}  •  q quit`;
+    const [lon, lat] = this.camera.center;
+    let activity = "";
+    if (this.state.tiles.pendingCount > 0) {
+      activity = `  ${formatTileLoadingStatus(this.state.tiles.pendingCount, spinner)}`;
+    } else if (this.labelQueryActive) {
+      activity = `  ${spinner} Loading labels…`;
+    }
+    return `${this.fileName}${activity}  z${this.camera.zoom}  ${lat.toFixed(5)}, ${lon.toFixed(5)}  ${this.state.info.stats.nodes.toLocaleString()} nodes  •  arrows/hjkl pan  +/- zoom  drag/wheel  0 fit  q quit`;
+  }
+}
+
+/** Open a local OSM PBF file in the interactive OpenTUI map viewer. */
+export async function openPbfViewer(filePath: string): Promise<void> {
+  if (!process.stdin.isTTY || !process.stdout.isTTY) {
+    throw Error("The osmix viewer requires an interactive terminal.");
+  }
+  const viewer = await TerminalMapViewer.create(basename(filePath));
+  const resources: { tileRenderer?: StyledTileRenderer } = {};
+  let loadError: unknown;
+  void createStyledTileRenderer({
+    onProgress: (message) => viewer.setProgress(message),
+  })
+    .then(async (created) => {
+      resources.tileRenderer = created;
+      if (viewer.renderer.isDestroyed) {
+        created.dispose();
+        return;
+      }
+      viewer.setLoadingMessage("Loading file in workers…");
+      const info = await created.loadPbfFile(resolve(filePath), basename(filePath));
+      if (viewer.renderer.isDestroyed) return;
+      viewer.setDataset(info, created);
+    })
+    .catch((error: unknown) => {
+      if (viewer.renderer.isDestroyed) return;
+      loadError = error;
+      resources.tileRenderer?.dispose();
+      viewer.setError(error);
+    });
+
+  try {
+    await viewer.waitUntilClosed();
+  } finally {
+    resources.tileRenderer?.dispose();
+  }
+  if (loadError !== undefined) throw loadError;
+}

--- a/packages/cli/test/args.test.ts
+++ b/packages/cli/test/args.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import { CliUsageError, parseCliArgs } from "../src/args.ts";
+
+describe("parseCliArgs", () => {
+  it("accepts one PBF path", () => {
+    expect(parseCliArgs(["monaco.pbf"])).toEqual({ kind: "view", filePath: "monaco.pbf" });
+  });
+
+  it("recognizes help", () => {
+    expect(parseCliArgs(["--help"])).toEqual({ kind: "help" });
+    expect(parseCliArgs(["-h"])).toEqual({ kind: "help" });
+  });
+
+  it("recognizes version", () => {
+    expect(parseCliArgs(["--version"])).toEqual({ kind: "version" });
+    expect(parseCliArgs(["-V"])).toEqual({ kind: "version" });
+  });
+
+  it.each([{ args: [] }, { args: ["one.pbf", "two.pbf"] }, { args: ["--unknown"] }])(
+    "rejects invalid arguments: $args",
+    ({ args }) => {
+      expect(() => parseCliArgs(args)).toThrow(CliUsageError);
+    },
+  );
+});

--- a/packages/cli/test/camera.test.ts
+++ b/packages/cli/test/camera.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+
+import { lonLatToWorld, MapCamera, worldToLonLat } from "../src/camera.ts";
+
+describe("MapCamera", () => {
+  it("fits bounds and centers the dataset", () => {
+    const camera = MapCamera.fitBounds([7.4, 43.72, 7.44, 43.75], {
+      width: 100,
+      height: 46,
+    });
+    const [lon, lat] = camera.center;
+    expect(lon).toBeCloseTo(7.42, 2);
+    expect(lat).toBeCloseTo(43.735, 2);
+    expect(camera.zoom).toBeGreaterThanOrEqual(10);
+  });
+
+  it("preserves the coordinate beneath an off-center zoom anchor", () => {
+    const viewport = { width: 100, height: 50 };
+    const anchor = { x: 20, y: 10 };
+    const camera = new MapCamera(0.55, 0.45, 8);
+    const beforeOrigin = camera.origin(viewport);
+    const before = {
+      x: (beforeOrigin.x + anchor.x) / camera.worldSize,
+      y: (beforeOrigin.y + anchor.y) / camera.worldSize,
+    };
+    camera.zoomBy(1, viewport, anchor);
+    const afterOrigin = camera.origin(viewport);
+    const after = {
+      x: (afterOrigin.x + anchor.x) / camera.worldSize,
+      y: (afterOrigin.y + anchor.y) / camera.worldSize,
+    };
+    expect(after.x).toBeCloseTo(before.x, 4);
+    expect(after.y).toBeCloseTo(before.y, 4);
+  });
+
+  it("round-trips projected coordinates", () => {
+    const coordinate: [number, number] = [7.420_56, 43.732_1];
+    expect(worldToLonLat(lonLatToWorld(coordinate))).toEqual([
+      expect.closeTo(coordinate[0], 8),
+      expect.closeTo(coordinate[1], 8),
+    ]);
+  });
+
+  it("wraps horizontal pans and clamps vertical pans", () => {
+    const camera = new MapCamera(0.99, 0.99, 0);
+    camera.panPixels(20, 1000);
+    expect(camera.centerX).toBeGreaterThanOrEqual(0);
+    expect(camera.centerX).toBeLessThan(1);
+    expect(camera.centerY).toBe(1);
+  });
+
+  it("projects the nearest world copy across the antimeridian", () => {
+    const center = lonLatToWorld([179.5, 0]);
+    const camera = new MapCamera(center.x, center.y, 4);
+    const projected = camera.project([-179.5, 0], { width: 100, height: 50 });
+
+    expect(projected.x).toBeGreaterThan(50);
+    expect(projected.x).toBeLessThan(70);
+    expect(projected.y).toBeCloseTo(25, 4);
+  });
+
+  it("splits visible geographic bounds at the antimeridian", () => {
+    const center = lonLatToWorld([179.5, 0]);
+    const camera = new MapCamera(center.x, center.y, 4);
+    const bboxes = camera.visibleBboxes({ width: 100, height: 50 });
+
+    expect(bboxes).toHaveLength(2);
+    expect(bboxes[0]![2]).toBe(180);
+    expect(bboxes[1]![0]).toBe(-180);
+    expect(bboxes[0]![1]).toBeLessThan(bboxes[0]![3]);
+  });
+});

--- a/packages/cli/test/executable-targets.test.ts
+++ b/packages/cli/test/executable-targets.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  executableTargets,
+  expectedReleaseAssetNames,
+  missingReleaseAssetNames,
+  releaseArchiveName,
+  targetDefines,
+} from "../scripts/executable-targets.ts";
+
+describe("standalone executable targets", () => {
+  it("covers every supported OpenTUI OS, architecture, and libc combination", () => {
+    expect(executableTargets.map(({ id }) => id)).toEqual([
+      "macos-arm64",
+      "macos-x64",
+      "linux-arm64-glibc",
+      "linux-x64-glibc",
+      "linux-arm64-musl",
+      "linux-x64-musl",
+      "windows-arm64",
+      "windows-x64",
+    ]);
+    expect(new Set(executableTargets.map(({ nativePackage }) => nativePackage)).size).toBe(8);
+  });
+
+  it("uses baseline Bun runtimes for supported x64 targets", () => {
+    const targets = new Map(executableTargets.map(({ id, bunTarget }) => [id, bunTarget]));
+    expect(targets.get("macos-x64")).toBe("bun-darwin-x64-baseline");
+    expect(targets.get("linux-x64-glibc")).toBe("bun-linux-x64-baseline");
+    expect(targets.get("windows-x64")).toBe("bun-windows-x64-baseline");
+    expect(targets.get("linux-x64-musl")).toBe("bun-linux-x64-musl");
+  });
+
+  it("defines the selected Linux libc and leaves other targets runtime-neutral", () => {
+    for (const target of executableTargets) {
+      const defines = targetDefines(target);
+      expect(defines["process.env.NODE_ENV"]).toBe(JSON.stringify("production"));
+      expect(defines["process.env.OPENTUI_LIBC"]).toBe(
+        target.libc ? JSON.stringify(target.libc) : undefined,
+      );
+    }
+  });
+
+  it("creates stable archives and a checksum manifest", () => {
+    expect(releaseArchiveName("1.2.3", executableTargets[0]!)).toBe(
+      "osmix-v1.2.3-macos-arm64.tar.gz",
+    );
+    const names = expectedReleaseAssetNames("1.2.3");
+    expect(names).toHaveLength(9);
+    expect(new Set(names).size).toBe(9);
+    expect(names.at(-1)).toBe("SHA256SUMS");
+  });
+
+  it("selects only missing release assets for an idempotent repair", () => {
+    const names = expectedReleaseAssetNames("1.2.3");
+    expect(missingReleaseAssetNames("1.2.3", names)).toEqual([]);
+    expect(missingReleaseAssetNames("1.2.3", names.slice(0, -2))).toEqual(names.slice(-2));
+  });
+});

--- a/packages/cli/test/map-labels.test.ts
+++ b/packages/cli/test/map-labels.test.ts
@@ -1,0 +1,406 @@
+import { getFixtureFileReadStream, PBFs } from "@osmix/test-utils";
+import { fromPbf, Osm, type LonLat, type OsmTags } from "osmix";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+import { MapCamera, type MapViewport, worldToLonLat } from "../src/camera.ts";
+import {
+  collectMapLabelCandidates,
+  layoutMapLabels,
+  resolveLabelMetadata,
+  truncateLabelText,
+  type LabelTextMeasurer,
+  type MapLabelCandidate,
+} from "../src/map-labels.ts";
+
+function candidate(overrides: Partial<MapLabelCandidate> = {}): MapLabelCandidate {
+  return {
+    anchor: { x: 40, y: 20 },
+    kind: "road",
+    placement: "center",
+    priority: 800,
+    stableKey: "candidate",
+    text: "Main St",
+    visibleLength: 10,
+    ...overrides,
+  };
+}
+
+const simpleMeasure: LabelTextMeasurer = (text, maxWidth) => {
+  const graphemes = [...new Intl.Segmenter(undefined, { granularity: "grapheme" }).segment(text)];
+  return truncateLabelText(
+    text,
+    graphemes.map(() => 1),
+    maxWidth,
+  );
+};
+
+function coordinateAt(camera: MapCamera, viewport: MapViewport, x: number, y: number): LonLat {
+  const origin = camera.origin(viewport);
+  return worldToLonLat({
+    x: (origin.x + x) / camera.worldSize,
+    y: (origin.y + y) / camera.worldSize,
+  });
+}
+
+function addWayAtScreen(
+  osm: Osm,
+  camera: MapCamera,
+  viewport: MapViewport,
+  id: number,
+  points: [number, number][],
+  tags: OsmTags,
+): void {
+  const refs: number[] = [];
+  for (const [index, point] of points.entries()) {
+    if (index === points.length - 1 && point[0] === points[0]?.[0] && point[1] === points[0]?.[1]) {
+      refs.push(refs[0]!);
+      continue;
+    }
+    const nodeId = id * 100 + index;
+    const [lon, lat] = coordinateAt(camera, viewport, point[0], point[1]);
+    osm.nodes.addNode({ id: nodeId, lon, lat });
+    refs.push(nodeId);
+  }
+  osm.ways.addWay({ id, refs, tags });
+}
+
+describe("resolveLabelMetadata", () => {
+  it("applies zoom thresholds to places and road classes", () => {
+    expect(resolveLabelMetadata({ place: "city", name: "City" }, "Point", 3)).toBeNull();
+    expect(resolveLabelMetadata({ place: "city", name: "City" }, "Point", 4)).toMatchObject({
+      kind: "place",
+      text: "City",
+    });
+    expect(resolveLabelMetadata({ highway: "primary", name: "A1" }, "LineString", 8)).toBeNull();
+    expect(resolveLabelMetadata({ highway: "primary", name: "A1" }, "LineString", 9)).toMatchObject(
+      {
+        kind: "road",
+      },
+    );
+    expect(
+      resolveLabelMetadata({ highway: "residential", name: "Main St" }, "LineString", 11),
+    ).toBeNull();
+    expect(
+      resolveLabelMetadata({ highway: "residential", name: "Main St" }, "LineString", 12),
+    ).toMatchObject({ kind: "road" });
+    expect(
+      resolveLabelMetadata({ highway: "footway", name: "Promenade" }, "LineString", 14),
+    ).toBeNull();
+    expect(
+      resolveLabelMetadata({ highway: "footway", name: "Promenade" }, "LineString", 15),
+    ).toMatchObject({
+      kind: "road",
+    });
+  });
+
+  it("applies water, site, and semantic POI thresholds", () => {
+    expect(resolveLabelMetadata({ natural: "water", name: "Lake" }, "Polygon", 8)).toMatchObject({
+      kind: "water",
+    });
+    expect(resolveLabelMetadata({ waterway: "river", name: "River" }, "LineString", 9)).toBeNull();
+    expect(
+      resolveLabelMetadata({ waterway: "river", name: "River" }, "LineString", 10),
+    ).toMatchObject({
+      kind: "water",
+    });
+    expect(resolveLabelMetadata({ leisure: "park", name: "Park" }, "Polygon", 12)).toMatchObject({
+      kind: "site",
+    });
+    expect(
+      resolveLabelMetadata({ amenity: "hospital", name: "Clinic" }, "Point", 14),
+    ).toMatchObject({
+      kind: "poi",
+    });
+    expect(resolveLabelMetadata({ amenity: "cafe", name: "Cafe" }, "Point", 14)).toBeNull();
+    expect(resolveLabelMetadata({ amenity: "cafe", name: "Cafe" }, "Point", 15)).toMatchObject({
+      kind: "poi",
+    });
+  });
+
+  it("prefers local names, then English, then road references", () => {
+    expect(
+      resolveLabelMetadata(
+        { highway: "primary", name: "Route locale", "name:en": "English Route", ref: "A1" },
+        "LineString",
+        10,
+      ),
+    ).toMatchObject({ text: "Route locale" });
+    expect(
+      resolveLabelMetadata(
+        { highway: "primary", "name:en": "English Route", ref: "A1" },
+        "LineString",
+        10,
+      ),
+    ).toMatchObject({ text: "English Route" });
+    expect(resolveLabelMetadata({ highway: "primary", ref: "A1" }, "LineString", 10)).toMatchObject(
+      {
+        text: "A1",
+      },
+    );
+  });
+
+  it("omits buildings, addresses, unnamed, and unclassified geometry", () => {
+    expect(resolveLabelMetadata({ building: "yes", name: "Tower" }, "Polygon", 16)).toBeNull();
+    expect(resolveLabelMetadata({ "addr:housenumber": "12" }, "Point", 16)).toBeNull();
+    expect(resolveLabelMetadata({ highway: "primary" }, "LineString", 16)).toBeNull();
+    expect(resolveLabelMetadata({ name: "Unknown" }, "Point", 16)).toBeNull();
+  });
+});
+
+describe("label text and collision layout", () => {
+  it("truncates by grapheme widths rather than JavaScript string length", () => {
+    expect(truncateLabelText("東京é", [2, 2, 1], 5)).toEqual({ text: "東京é", width: 5 });
+    expect(truncateLabelText("東京é", [2, 2, 1], 4)).toEqual({ text: "東…", width: 3 });
+  });
+
+  it("keeps higher-priority labels when padded collision boxes overlap", () => {
+    const labels = layoutMapLabels(
+      [
+        candidate({ kind: "poi", priority: 600, stableKey: "poi", text: "Cafe" }),
+        candidate({ kind: "place", priority: 1_000, stableKey: "place", text: "Monaco" }),
+      ],
+      { width: 80, height: 24 },
+      simpleMeasure,
+    );
+
+    expect(labels).toHaveLength(1);
+    expect(labels[0]).toMatchObject({ kind: "place", text: "Monaco" });
+  });
+
+  it("places point labels to the right and falls back to the left", () => {
+    const labels = layoutMapLabels(
+      [
+        candidate({ anchor: { x: 35, y: 20 }, kind: "place", priority: 1_000, text: "Town" }),
+        candidate({
+          anchor: { x: 30, y: 20 },
+          kind: "poi",
+          placement: "point",
+          priority: 600,
+          text: "Cafe",
+        }),
+      ],
+      { width: 80, height: 24 },
+      simpleMeasure,
+    );
+
+    expect(labels).toHaveLength(2);
+    expect(labels.find((label) => label.kind === "poi")?.x).toBe(24);
+  });
+
+  it("caps labels at 24 columns and keeps backplates within the viewport", () => {
+    const labels = layoutMapLabels(
+      [
+        candidate({
+          anchor: { x: 40, y: 20 },
+          text: "A very long avenue name that must be shortened",
+        }),
+      ],
+      { width: 80, height: 24 },
+      simpleMeasure,
+    );
+
+    expect(labels[0]?.width).toBeLessThanOrEqual(24);
+    expect(labels[0]?.text.endsWith("…")).toBe(true);
+    expect(labels[0]!.backplateX).toBeGreaterThanOrEqual(0);
+    expect(labels[0]!.backplateX + labels[0]!.backplateWidth).toBeLessThanOrEqual(80);
+  });
+});
+
+describe("collectMapLabelCandidates", () => {
+  it("classifies ways and relations before retrieving their geometry", () => {
+    const viewport = { width: 100, height: 60 };
+    const camera = new MapCamera(0.5, 0.5, 10);
+    const osm = new Osm();
+    addWayAtScreen(
+      osm,
+      camera,
+      viewport,
+      1,
+      [
+        [20, 15],
+        [80, 15],
+        [80, 45],
+        [20, 45],
+        [20, 15],
+      ],
+      { name: "Unclassified area" },
+    );
+    osm.relations.addRelation({
+      id: 2,
+      members: [{ type: "way", ref: 1, role: "outer" }],
+      tags: { type: "multipolygon", name: "Unclassified relation" },
+    });
+    osm.buildIndexes();
+    osm.buildSpatialIndexes();
+    const getWayCoordinates = vi.spyOn(osm.ways, "getCoordinates");
+    const getRelationGeometry = vi.spyOn(osm.relations, "getRelationGeometry");
+
+    expect(collectMapLabelCandidates(osm, camera, viewport)).toEqual([]);
+    expect(getWayCoordinates).not.toHaveBeenCalled();
+    expect(getRelationGeometry).not.toHaveBeenCalled();
+  });
+
+  it("accepts worker-owned way and relation search providers", () => {
+    const viewport = { width: 100, height: 60 };
+    const camera = new MapCamera(0.5, 0.5, 10);
+    const osm = new Osm();
+    addWayAtScreen(
+      osm,
+      camera,
+      viewport,
+      1,
+      [
+        [10, 20],
+        [90, 20],
+      ],
+      { highway: "primary", name: "Indexed Road" },
+    );
+    osm.buildIndexes();
+    osm.buildSpatialIndexes();
+    const osmWaySearch = vi.spyOn(osm.ways, "intersects");
+    const osmRelationSearch = vi.spyOn(osm.relations, "intersects");
+
+    const candidates = collectMapLabelCandidates(osm, camera, viewport, {
+      relations: { intersects: () => [] },
+      ways: { intersects: () => [0] },
+    });
+
+    expect(candidates.map((candidate) => candidate.text)).toEqual(["Indexed Road"]);
+    expect(osmWaySearch).not.toHaveBeenCalled();
+    expect(osmRelationSearch).not.toHaveBeenCalled();
+  });
+
+  it("deduplicates named lines by retaining the longest visible geometry", () => {
+    const viewport = { width: 100, height: 60 };
+    const camera = new MapCamera(0.5, 0.5, 10);
+    const osm = new Osm();
+    addWayAtScreen(
+      osm,
+      camera,
+      viewport,
+      1,
+      [
+        [10, 20],
+        [90, 20],
+      ],
+      {
+        highway: "primary",
+        name: "Main Road",
+      },
+    );
+    addWayAtScreen(
+      osm,
+      camera,
+      viewport,
+      2,
+      [
+        [20, 40],
+        [40, 40],
+      ],
+      {
+        highway: "primary",
+        name: "Main Road",
+      },
+    );
+    osm.buildIndexes();
+    osm.buildSpatialIndexes();
+
+    const candidates = collectMapLabelCandidates(osm, camera, viewport);
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]?.text).toBe("Main Road");
+    expect(candidates[0]?.visibleLength).toBeCloseTo(80, 1);
+    expect(candidates[0]?.anchor.x).toBeCloseTo(50, 1);
+  });
+
+  it("suppresses a named area member when its relation supplies the label", () => {
+    const viewport = { width: 100, height: 60 };
+    const camera = new MapCamera(0.5, 0.5, 10);
+    const osm = new Osm();
+    addWayAtScreen(
+      osm,
+      camera,
+      viewport,
+      1,
+      [
+        [20, 15],
+        [80, 15],
+        [80, 45],
+        [20, 45],
+        [20, 15],
+      ],
+      {
+        natural: "water",
+        name: "Relation Lake",
+      },
+    );
+    osm.relations.addRelation({
+      id: 2,
+      members: [{ type: "way", ref: 1, role: "outer" }],
+      tags: { type: "multipolygon", natural: "water", name: "Relation Lake" },
+    });
+    osm.buildIndexes();
+    osm.buildSpatialIndexes();
+
+    const candidates = collectMapLabelCandidates(osm, camera, viewport);
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]?.stableKey).toBe("relation:2:polygon");
+  });
+});
+
+describe("Monaco label detail", () => {
+  let osm: Osm;
+
+  beforeAll(async () => {
+    osm = await fromPbf(getFixtureFileReadStream(PBFs["monaco"]!.url));
+  });
+
+  it("shows major road labels at fit zoom and progressively richer close detail", () => {
+    const viewport = { width: 100, height: 62 };
+    const fitted = MapCamera.fitBounds(osm.bbox(), viewport);
+    const overview = collectMapLabelCandidates(osm, fitted, viewport);
+    const detailed = collectMapLabelCandidates(
+      osm,
+      new MapCamera(fitted.centerX, fitted.centerY, 11),
+      viewport,
+    );
+    const close = collectMapLabelCandidates(
+      osm,
+      new MapCamera(fitted.centerX, fitted.centerY, 15),
+      viewport,
+    );
+
+    expect(fitted.zoom).toBe(10);
+    expect(overview.some((label) => label.kind === "road")).toBe(true);
+    expect(detailed.some((label) => label.priority === 840)).toBe(true);
+    expect(close.some((label) => label.kind === "poi" || label.priority <= 820)).toBe(true);
+  });
+
+  it("lays out fixture labels without overlap or status-row intrusion", () => {
+    const pixelViewport = { width: 100, height: 62 };
+    const camera = MapCamera.fitBounds(osm.bbox(), pixelViewport);
+    const candidates = collectMapLabelCandidates(osm, camera, pixelViewport);
+    const labels = layoutMapLabels(candidates, { width: 100, height: 31 }, simpleMeasure);
+
+    expect(labels.length).toBeGreaterThan(0);
+    for (const [index, label] of labels.entries()) {
+      expect(label.y).toBeLessThan(31);
+      const a = {
+        left: label.backplateX - 1,
+        right: label.backplateX + label.backplateWidth,
+        top: label.y - 1,
+        bottom: label.y + 1,
+      };
+      for (const other of labels.slice(index + 1)) {
+        const b = {
+          left: other.backplateX - 1,
+          right: other.backplateX + other.backplateWidth,
+          top: other.y - 1,
+          bottom: other.y + 1,
+        };
+        const overlaps =
+          a.left <= b.right && a.right >= b.left && a.top <= b.bottom && a.bottom >= b.top;
+        expect(overlaps).toBe(false);
+      }
+    }
+  });
+});

--- a/packages/cli/test/map-pixels.test.ts
+++ b/packages/cli/test/map-pixels.test.ts
@@ -1,0 +1,316 @@
+import type { Tile } from "osmix";
+import { describe, expect, it } from "vitest";
+
+import { MapCamera, TILE_SIZE } from "../src/camera.ts";
+import {
+  formatTileLoadingStatus,
+  isShimmerCell,
+  MAP_BACKGROUND,
+  OsmTileLoader,
+  renderMapPixels,
+  SHIMMER_PERIOD,
+  TILE_LOADING_BASE,
+} from "../src/map-pixels.ts";
+
+function solidTile(red: number, green: number, blue: number, alpha: number) {
+  const data = new Uint8ClampedArray(TILE_SIZE * TILE_SIZE * 4);
+  for (let offset = 0; offset < data.length; offset += 4) {
+    data[offset] = red;
+    data[offset + 1] = green;
+    data[offset + 2] = blue;
+    data[offset + 3] = alpha;
+  }
+  return { data };
+}
+
+function pixel(pixels: Uint8ClampedArray, width: number, x: number, y: number): number[] {
+  const offset = (y * width + x) * 4;
+  return Array.from(pixels.slice(offset, offset + 4));
+}
+
+function tinyTile(value: number) {
+  return { data: new Uint8ClampedArray([value, value, value, 255]) };
+}
+
+async function flushTileWork(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe("renderMapPixels", () => {
+  it("composites raster alpha over the map background", () => {
+    const pixels = renderMapPixels(new MapCamera(0.5, 0.5, 0), { width: 2, height: 2 }, () =>
+      solidTile(207, 117, 13, 128),
+    );
+    expect(Array.from(pixels.slice(0, 4))).toEqual([107, 67, 13, 255]);
+  });
+
+  it("leaves transparent raster pixels at the map background", () => {
+    const pixels = renderMapPixels(new MapCamera(0.5, 0.5, 0), { width: 1, height: 1 }, () =>
+      solidTile(255, 255, 255, 0),
+    );
+    expect([...pixels]).toEqual([...MAP_BACKGROUND, 255]);
+  });
+
+  it("wraps horizontal world tiles before requesting raster data", () => {
+    const requested: Tile[] = [];
+    const getTile = (tile: Tile) => {
+      requested.push(tile);
+      return solidTile(0, 0, 0, 0);
+    };
+    renderMapPixels(new MapCamera(0, 0.5, 0), { width: 4, height: 1 }, getTile);
+    expect(requested.length).toBeGreaterThan(0);
+    for (const tile of requested) expect(tile[0]).toBe(0);
+  });
+
+  it("fills missing tiles with the map background and records their clipped regions", () => {
+    const camera = new MapCamera(0.5, 0.5, 1);
+    const viewport = { width: 300, height: 2 };
+    const getTile = (tile: Tile) => (tile[0] === 0 ? null : solidTile(80, 90, 100, 255));
+    const pendingRegions: Array<{ bottom: number; left: number; right: number; top: number }> = [];
+    const pixels = renderMapPixels(camera, viewport, getTile, pendingRegions);
+
+    expect(TILE_LOADING_BASE).toBe(MAP_BACKGROUND);
+    expect(pixel(pixels, viewport.width, 24, 0)).toEqual([...TILE_LOADING_BASE, 255]);
+    expect(pixel(pixels, viewport.width, 250, 0)).toEqual([80, 90, 100, 255]);
+    expect(pendingRegions).toEqual([
+      { bottom: 1, left: 0, right: 150, top: 0 },
+      { bottom: 2, left: 0, right: 150, top: 1 },
+    ]);
+  });
+
+  it("changes at most fifteen percent of pending cells between shimmer phases", () => {
+    const width = SHIMMER_PERIOD * 10;
+    const height = 20;
+    let changed = 0;
+    let highlighted = 0;
+    for (let y = 0; y < height; y++) {
+      for (let x = 0; x < width; x++) {
+        const first = isShimmerCell(x, y, 0);
+        const second = isShimmerCell(x, y, 1);
+        if (first) highlighted++;
+        if (first !== second) changed++;
+      }
+    }
+
+    expect(highlighted / (width * height)).toBeCloseTo(1 / SHIMMER_PERIOD, 5);
+    expect(changed / (width * height)).toBeLessThanOrEqual(0.15);
+  });
+});
+
+describe("OsmTileLoader", () => {
+  it("self-starts cache misses and exposes completed tiles progressively", async () => {
+    const rendered: string[] = [];
+    const resolvers = new Map<string, (tile: ReturnType<typeof tinyTile>) => void>();
+    const loader = new OsmTileLoader({
+      renderTile: (tile, generation) => {
+        const key = tile.join("/");
+        rendered.push(`${key}@${generation}`);
+        return new Promise((resolve) => resolvers.set(key, resolve));
+      },
+    });
+    const first: Tile = [1, 2, 3];
+    const second: Tile = [2, 2, 3];
+
+    loader.beginFrame();
+    expect(loader.getTile(first)).toBeNull();
+    expect(loader.getTile(second)).toBeNull();
+    loader.endFrame();
+    expect(loader.pendingCount).toBe(2);
+
+    await Promise.resolve();
+    expect(rendered).toEqual(["1/2/3@1"]);
+    resolvers.get("1/2/3")!(tinyTile(1));
+    await flushTileWork();
+    loader.beginFrame();
+    expect(loader.getTile(first)?.data[0]).toBe(1);
+    expect(loader.getTile(second)).toBeNull();
+    loader.endFrame();
+    expect(loader.pendingCount).toBe(1);
+    expect(rendered).toEqual(["1/2/3@1", "2/2/3@1"]);
+    resolvers.get("2/2/3")!(tinyTile(2));
+    await flushTileWork();
+  });
+
+  it("drops queued work that is not requested by the latest viewport", async () => {
+    const rendered: string[] = [];
+    let resolveBlocker!: (tile: ReturnType<typeof tinyTile>) => void;
+    const loader = new OsmTileLoader({
+      renderTile: (tile) => {
+        rendered.push(tile.join("/"));
+        if (tile[0] === 0) return new Promise((resolve) => (resolveBlocker = resolve));
+        return tinyTile(1);
+      },
+    });
+
+    loader.beginFrame();
+    loader.getTile([0, 0, 5]);
+    loader.getTile([1, 1, 5]);
+    loader.getTile([2, 2, 5]);
+    loader.endFrame();
+    await Promise.resolve();
+    expect(rendered).toEqual(["0/0/5"]);
+
+    loader.beginFrame();
+    loader.getTile([8, 8, 5]);
+    loader.endFrame();
+
+    expect(loader.pendingCount).toBe(1);
+    resolveBlocker(tinyTile(0));
+    await flushTileWork();
+    expect(rendered).toEqual(["0/0/5", "8/8/5"]);
+  });
+
+  it("starts center-most viewport tiles first", async () => {
+    const started: Array<{ generation: number; tile: Tile }> = [];
+    const loader = new OsmTileLoader({
+      renderTile: (tile, generation) => {
+        started.push({ generation, tile });
+        return new Promise(() => undefined);
+      },
+    });
+    const camera = new MapCamera(2.25 / 8, 2.25 / 8, 3);
+
+    loader.beginFrame(42);
+    renderMapPixels(camera, { width: 400, height: 400 }, loader.getTile);
+    loader.endFrame();
+    await Promise.resolve();
+
+    expect(started).toEqual([{ generation: 42, tile: [2, 2, 3] }]);
+    loader.dispose();
+  });
+
+  it("reorders overlapping queued tiles for the latest viewport", async () => {
+    const started: number[] = [];
+    let releaseBlocker!: (tile: ReturnType<typeof tinyTile>) => void;
+    const loader = new OsmTileLoader({
+      renderTile: (tile) => {
+        started.push(tile[0]);
+        if (tile[0] === 0) return new Promise((resolve) => (releaseBlocker = resolve));
+        return new Promise(() => undefined);
+      },
+    });
+    loader.beginFrame(1);
+    loader.getTile([0, 0, 5]);
+    loader.getTile([1, 0, 5]);
+    loader.getTile([2, 0, 5]);
+    loader.endFrame();
+    await Promise.resolve();
+
+    loader.beginFrame(2);
+    loader.getTile([2, 0, 5]);
+    loader.getTile([1, 0, 5]);
+    loader.endFrame();
+    releaseBlocker(tinyTile(0));
+    await flushTileWork();
+
+    expect(started).toEqual([0, 2]);
+    loader.dispose();
+  });
+
+  it("keeps the default cache bounded to 64 least-recently-used tiles", async () => {
+    const loader = new OsmTileLoader({
+      renderTile: (tile) => tinyTile(tile[0]),
+    });
+    for (let index = 0; index < 65; index++) {
+      loader.beginFrame();
+      loader.getTile([index, 0, 8]);
+      loader.endFrame();
+      await flushTileWork();
+    }
+
+    expect(loader.cacheSize).toBe(64);
+    loader.beginFrame();
+    expect(loader.getTile([0, 0, 8])).toBeNull();
+    expect(loader.getTile([64, 0, 8])?.data[0]).toBe(64);
+    loader.endFrame();
+    loader.dispose();
+  });
+
+  it("renders concurrently and refills slots as jobs finish out of order", async () => {
+    const resolvers = new Map<number, (tile: ReturnType<typeof tinyTile>) => void>();
+    const started: number[] = [];
+    const loader = new OsmTileLoader({
+      maxConcurrentTiles: 2,
+      renderTile: (tile) => {
+        started.push(tile[0]);
+        return new Promise((resolve) => resolvers.set(tile[0], resolve));
+      },
+    });
+    loader.beginFrame();
+    loader.getTile([1, 0, 8]);
+    loader.getTile([2, 0, 8]);
+    loader.getTile([3, 0, 8]);
+    loader.endFrame();
+
+    await Promise.resolve();
+    expect(started).toEqual([1, 2]);
+    resolvers.get(2)!(tinyTile(2));
+    await flushTileWork();
+    expect(started).toEqual([1, 2, 3]);
+    expect(loader.pendingCount).toBe(2);
+
+    resolvers.get(3)!(tinyTile(3));
+    resolvers.get(1)!(tinyTile(1));
+    await flushTileWork();
+    expect(loader.pendingCount).toBe(0);
+  });
+
+  it("does not redraw stale completions but reuses their cached result", async () => {
+    let resolveOld!: (tile: ReturnType<typeof tinyTile>) => void;
+    let completions = 0;
+    const loader = new OsmTileLoader({
+      onTileComplete: () => completions++,
+      renderTile: () => new Promise((resolve) => (resolveOld = resolve)),
+    });
+    const oldTile: Tile = [1, 1, 8];
+    loader.beginFrame();
+    loader.getTile(oldTile);
+    loader.endFrame();
+    await Promise.resolve();
+
+    loader.beginFrame();
+    loader.getTile([2, 2, 8]);
+    loader.endFrame();
+    resolveOld(tinyTile(1));
+    await flushTileWork();
+
+    expect(completions).toBe(0);
+    loader.beginFrame();
+    expect(loader.getTile(oldTile)?.data[0]).toBe(1);
+    loader.endFrame();
+    loader.dispose();
+  });
+
+  it("stops work after disposal and propagates rendering errors", async () => {
+    const disposed = new OsmTileLoader({ renderTile: () => tinyTile(1) });
+    disposed.beginFrame();
+    disposed.getTile([1, 1, 1]);
+    disposed.endFrame();
+    disposed.dispose();
+    expect(disposed.pendingCount).toBe(0);
+    expect(disposed.processPending()).toBe(0);
+    expect(disposed.getTile([1, 1, 1])).toBeNull();
+    expect(disposed.pendingCount).toBe(0);
+
+    let failure: unknown;
+    const failing = new OsmTileLoader({
+      onError: (error) => (failure = error),
+      renderTile: () => {
+        throw Error("tile failed");
+      },
+    });
+    failing.beginFrame();
+    failing.getTile([1, 1, 1]);
+    failing.endFrame();
+    await flushTileWork();
+    expect(failing.pendingCount).toBe(0);
+    expect(failure).toEqual(Error("tile failed"));
+  });
+});
+
+describe("tile loading status", () => {
+  it("formats singular and plural pending counts", () => {
+    expect(formatTileLoadingStatus(1, "⠋")).toBe("⠋ Rendering 1 tile…");
+    expect(formatTileLoadingStatus(3, "⠙")).toBe("⠙ Rendering 3 tiles…");
+  });
+});

--- a/packages/cli/test/map-style.test.ts
+++ b/packages/cli/test/map-style.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+
+import { DARK_MAP_COLORS, resolveFeatureStyles } from "../src/map-style.ts";
+
+describe("resolveFeatureStyles", () => {
+  it("lifts feature colors while keeping the dark background anchored", () => {
+    expect(DARK_MAP_COLORS.background).toEqual([7, 17, 13, 255]);
+    expect(DARK_MAP_COLORS.vegetation).toEqual([59, 88, 74, 255]);
+    expect(DARK_MAP_COLORS.residential).toEqual([181, 186, 181, 255]);
+    expect(DARK_MAP_COLORS.motorway).toEqual([232, 143, 126, 255]);
+    expect(DARK_MAP_COLORS.boundary).toEqual([158, 133, 167, 190]);
+  });
+
+  it("uses zoom-aware cased road hierarchy without duplicate label styles", () => {
+    expect(resolveFeatureStyles({ highway: "motorway" }, "LineString", 6)).toEqual([]);
+    const styles = resolveFeatureStyles({ highway: "motorway" }, "LineString", 16);
+
+    expect(styles).toHaveLength(1);
+    expect(styles[0]).toMatchObject({
+      kind: "line",
+      color: DARK_MAP_COLORS.motorway,
+      width: 5,
+      casingColor: DARK_MAP_COLORS.roadCasing,
+      casingWidth: 7,
+    });
+  });
+
+  it("shows uncased minor roads and rail in the low-zoom overview", () => {
+    expect(resolveFeatureStyles({ highway: "tertiary" }, "LineString", 8)).toEqual([]);
+    expect(resolveFeatureStyles({ highway: "tertiary" }, "LineString", 9)[0]).toMatchObject({
+      kind: "line",
+      width: 1,
+      casingColor: undefined,
+    });
+    expect(resolveFeatureStyles({ highway: "residential" }, "LineString", 9)[0]).toMatchObject({
+      kind: "line",
+      width: 1,
+      casingColor: undefined,
+    });
+    expect(resolveFeatureStyles({ highway: "service" }, "LineString", 9)).toEqual([]);
+    expect(resolveFeatureStyles({ highway: "service" }, "LineString", 10)[0]).toMatchObject({
+      kind: "line",
+      width: 1,
+      casingColor: undefined,
+    });
+    expect(resolveFeatureStyles({ railway: "rail" }, "LineString", 9)[0]).toMatchObject({
+      kind: "line",
+      width: 1,
+      casingColor: undefined,
+    });
+  });
+
+  it("adds buildings and semantic points only at their detail zooms", () => {
+    expect(resolveFeatureStyles({ building: "yes" }, "Polygon", 12)).toEqual([]);
+    expect(resolveFeatureStyles({ building: "yes" }, "Polygon", 13)[0]).toMatchObject({
+      kind: "fill",
+      color: DARK_MAP_COLORS.building,
+      outlineColor: DARK_MAP_COLORS.buildingOutline,
+    });
+
+    expect(resolveFeatureStyles({ amenity: "hospital" }, "Point", 13)).toEqual([]);
+    expect(resolveFeatureStyles({ amenity: "hospital" }, "Point", 14)[0]).toMatchObject({
+      kind: "point",
+      color: DARK_MAP_COLORS.medical,
+      size: 1,
+      symbol: "plus",
+    });
+    expect(resolveFeatureStyles({ amenity: "hospital" }, "Point", 16)[0]).toMatchObject({
+      size: 2,
+    });
+  });
+
+  it("classifies land colors and ignores unclassified or label-only geometry", () => {
+    expect(resolveFeatureStyles({ natural: "wood" }, "Polygon", 10)[0]).toMatchObject({
+      color: DARK_MAP_COLORS.vegetation,
+    });
+    expect(resolveFeatureStyles({ landuse: "industrial" }, "Polygon", 10)[0]).toMatchObject({
+      color: DARK_MAP_COLORS.industrial,
+    });
+    expect(resolveFeatureStyles({ name: "Nowhere" }, "Point", 16)).toEqual([]);
+    expect(resolveFeatureStyles({ source: "survey" }, "LineString", 16)).toEqual([]);
+  });
+
+  it("uses semantic colors instead of explicit OSM colour tags", () => {
+    const [style] = resolveFeatureStyles(
+      { highway: "primary", colour: "#00ff00" },
+      "LineString",
+      16,
+    );
+    expect(style).toMatchObject({ color: DARK_MAP_COLORS.primary });
+  });
+
+  it("orders tunnels below roads, bridges above them, and transit last", () => {
+    const [tunnel] = resolveFeatureStyles({ highway: "primary", tunnel: "yes" }, "LineString", 14);
+    const [road] = resolveFeatureStyles({ highway: "primary" }, "LineString", 14);
+    const [bridge] = resolveFeatureStyles({ highway: "primary", bridge: "yes" }, "LineString", 14);
+    const [rail] = resolveFeatureStyles({ railway: "rail" }, "LineString", 14);
+
+    expect(tunnel!.order).toBeLessThan(road!.order);
+    expect(road!.order).toBeLessThan(bridge!.order);
+    expect(bridge!.order).toBeLessThan(rail!.order);
+  });
+});

--- a/packages/cli/test/regional-stress.ts
+++ b/packages/cli/test/regional-stress.ts
@@ -1,0 +1,378 @@
+import { stat } from "node:fs/promises";
+
+import { getOsmixCapabilities, type Tile } from "osmix";
+
+import { MapCamera, TILE_SIZE, type MapViewport } from "../src/camera.ts";
+import {
+  OsmTileLoader,
+  renderMapPixels,
+  type PendingTileRegion,
+  type TileImage,
+} from "../src/map-pixels.ts";
+import { createStyledTileRenderer } from "../src/tile-renderer.ts";
+
+const HEARTBEAT_INTERVAL_MS = 25;
+const ANIMATION_PHASE_MS = 100;
+const MAX_MAIN_LOOP_STALL_MS = 250;
+const MIN_ANIMATION_RATE_HZ = 8;
+const DEFAULT_STAGE_TIMEOUT_MS = 10 * 60_000;
+const RAPID_PAN_DELAY_MS = 15;
+const CLOSE_ZOOM = 14;
+
+interface LabelMetric {
+  candidates: number;
+  latencyMs: number;
+  revisionMatched: boolean;
+}
+
+interface RevisionMetric {
+  center: [number, number];
+  initialPendingTiles: number;
+  label?: LabelMetric;
+  name: string;
+  pendingRegions: number;
+  requestedTiles: Set<string>;
+  revision: number;
+  submittedAt: number;
+  tileSettleLatencyMs?: number;
+  worldCenter: [number, number];
+  zoom: number;
+}
+
+interface TileJobMetric {
+  generation: number;
+  latencyMs: number;
+  outcome: "cancelled" | "failed" | "rendered";
+  tile: string;
+}
+
+function round(value: number): number {
+  return Math.round(value * 10) / 10;
+}
+
+function delay(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+function percentile(values: number[], quantile: number): number | null {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const index = Math.min(sorted.length - 1, Math.ceil(sorted.length * quantile) - 1);
+  return round(sorted[index]!);
+}
+
+function tileKey(tile: Tile): string {
+  return `${tile[2]}/${tile[0]}/${tile[1]}`;
+}
+
+function positiveInteger(value: string | undefined, fallback: number): number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : fallback;
+}
+
+const filePath = process.env["OSMIX_CLI_STRESS_PBF"];
+if (!filePath) {
+  console.log("Set OSMIX_CLI_STRESS_PBF to run the regional CLI stress harness.");
+  process.exit(0);
+}
+
+const stageTimeoutMs = positiveInteger(
+  process.env["OSMIX_CLI_STRESS_TIMEOUT_MS"],
+  DEFAULT_STAGE_TIMEOUT_MS,
+);
+const file = await stat(filePath);
+const capabilities = getOsmixCapabilities();
+const startedAt = performance.now();
+const rssBeforeRenderer = process.memoryUsage.rss();
+let peakRssBytes = rssBeforeRenderer;
+let previousHeartbeat = startedAt;
+let maxHeartbeatGapMs = 0;
+let maxMainLoopStallMs = 0;
+let heartbeatTicks = 0;
+let lastAnimationPhase = -1;
+let lastAnimationPhaseAt = startedAt;
+let maxAnimationPhaseGapMs = 0;
+const animationPhases = new Set<number>();
+const heartbeat = setInterval(() => {
+  const now = performance.now();
+  const heartbeatGap = now - previousHeartbeat;
+  maxHeartbeatGapMs = Math.max(maxHeartbeatGapMs, heartbeatGap);
+  maxMainLoopStallMs = Math.max(maxMainLoopStallMs, heartbeatGap - HEARTBEAT_INTERVAL_MS);
+  previousHeartbeat = now;
+  heartbeatTicks++;
+  peakRssBytes = Math.max(peakRssBytes, process.memoryUsage.rss());
+
+  const phase = Math.floor((now - startedAt) / ANIMATION_PHASE_MS);
+  animationPhases.add(phase);
+  if (phase !== lastAnimationPhase) {
+    if (lastAnimationPhase !== -1) {
+      maxAnimationPhaseGapMs = Math.max(maxAnimationPhaseGapMs, now - lastAnimationPhaseAt);
+    }
+    lastAnimationPhase = phase;
+    lastAnimationPhaseAt = now;
+  }
+}, HEARTBEAT_INTERVAL_MS);
+
+let progressEvents = 0;
+let sharedTransferProgressEvents = 0;
+let workerRestartProgressEvents = 0;
+const rendererCreatedAt = performance.now();
+const renderer = await createStyledTileRenderer({
+  onProgress: (message) => {
+    progressEvents++;
+    if (message.includes("Sharing map indexes")) sharedTransferProgressEvents++;
+    if (/restart/i.test(message)) workerRestartProgressEvents++;
+  },
+});
+const rendererStartupMs = performance.now() - rendererCreatedAt;
+let tileFailure: unknown;
+const tileJobs: TileJobMetric[] = [];
+let activeTileJobs = 0;
+
+try {
+  const loadStartedAt = performance.now();
+  const info = await renderer.loadPbfFile(filePath, "regional-stress");
+  const loadLatencyMs = performance.now() - loadStartedAt;
+  const rssAfterLoadBytes = process.memoryUsage.rss();
+  peakRssBytes = Math.max(peakRssBytes, rssAfterLoadBytes);
+  const viewport: MapViewport = { width: 120, height: 78 };
+  const camera = MapCamera.fitBounds(info.bbox, viewport);
+  const revisions: RevisionMetric[] = [];
+  const loader = new OsmTileLoader({
+    maxConcurrentTiles: renderer.workerCount,
+    onError: (error) => {
+      tileFailure = error;
+    },
+    onGenerationChange: (generation) => renderer.cancelBefore(generation),
+    renderTile: async (tile, generation) => {
+      const tileStartedAt = performance.now();
+      activeTileJobs++;
+      try {
+        const rendered = await renderer.renderTile(tile, generation);
+        tileJobs.push({
+          generation,
+          latencyMs: performance.now() - tileStartedAt,
+          outcome: rendered ? "rendered" : "cancelled",
+          tile: tileKey(tile),
+        });
+        return rendered;
+      } catch (error) {
+        tileJobs.push({
+          generation,
+          latencyMs: performance.now() - tileStartedAt,
+          outcome: "failed",
+          tile: tileKey(tile),
+        });
+        throw error;
+      } finally {
+        activeTileJobs--;
+      }
+    },
+  });
+
+  const submitRevision = (name: string, revision: number): RevisionMetric => {
+    const submittedAt = performance.now();
+    const requestedTiles = new Set<string>();
+    const pendingRegions: PendingTileRegion[] = [];
+    loader.beginFrame(revision);
+    renderMapPixels(
+      camera,
+      viewport,
+      (tile): TileImage | null => {
+        requestedTiles.add(tileKey(tile));
+        return loader.getTile(tile);
+      },
+      pendingRegions,
+    );
+    loader.endFrame();
+    const metric: RevisionMetric = {
+      center: camera.center,
+      initialPendingTiles: loader.pendingCount,
+      name,
+      pendingRegions: pendingRegions.length,
+      requestedTiles,
+      revision,
+      submittedAt,
+      worldCenter: [camera.centerX, camera.centerY],
+      zoom: camera.zoom,
+    };
+    revisions.push(metric);
+    return metric;
+  };
+
+  const waitUntil = async (description: string, ready: () => boolean): Promise<void> => {
+    const deadline = performance.now() + stageTimeoutMs;
+    while (!ready()) {
+      if (tileFailure !== undefined) throw tileFailure;
+      if (performance.now() > deadline) throw Error(`Timed out waiting for ${description}`);
+      await delay(HEARTBEAT_INTERVAL_MS);
+    }
+    if (tileFailure !== undefined) throw tileFailure;
+  };
+
+  const waitForTiles = async (metric: RevisionMetric, includeStaleJobs = false): Promise<void> => {
+    await waitUntil(
+      `${metric.name} tiles`,
+      () => loader.pendingCount === 0 && (!includeStaleJobs || activeTileJobs === 0),
+    );
+    metric.tileSettleLatencyMs = performance.now() - metric.submittedAt;
+  };
+
+  const queryLabels = async (metric: RevisionMetric): Promise<void> => {
+    const labelStartedAt = performance.now();
+    const result = await renderer.queryLabels({
+      centerX: metric.worldCenter[0],
+      centerY: metric.worldCenter[1],
+      revision: metric.revision,
+      viewport,
+      zoom: metric.zoom,
+    });
+    metric.label = {
+      candidates: result.candidates.length,
+      latencyMs: performance.now() - labelStartedAt,
+      revisionMatched: result.revision === metric.revision,
+    };
+    if (!metric.label.revisionMatched) {
+      throw Error(`Label query returned revision ${result.revision}, expected ${metric.revision}`);
+    }
+  };
+
+  const settleRevision = async (metric: RevisionMetric): Promise<void> => {
+    if (renderer.labelsConcurrent) {
+      await Promise.all([waitForTiles(metric), queryLabels(metric)]);
+    } else {
+      await waitForTiles(metric);
+      await queryLabels(metric);
+    }
+  };
+
+  let revision = 1;
+  const fit = submitRevision("fit", revision++);
+  await settleRevision(fit);
+
+  while (camera.zoom < CLOSE_ZOOM) camera.zoomBy(1, viewport);
+  const zoom = submitRevision("close-zoom", revision++);
+  await settleRevision(zoom);
+
+  const panDistance = TILE_SIZE * 1.25;
+  const panDeltas: Array<[number, number]> = [
+    [panDistance, 0],
+    [panDistance, panDistance],
+    [panDistance, -panDistance * 2],
+    [-panDistance * 4, panDistance],
+    [panDistance, panDistance * 2],
+    [panDistance, panDistance],
+  ];
+  const panRevisions: RevisionMetric[] = [];
+  for (const [index, delta] of panDeltas.entries()) {
+    camera.panPixels(delta[0], delta[1]);
+    panRevisions.push(submitRevision(`rapid-pan-${index + 1}`, revision++));
+    if (index < panDeltas.length - 1) await delay(RAPID_PAN_DELAY_MS);
+  }
+  const finalPan = panRevisions.at(-1)!;
+  if (renderer.labelsConcurrent) {
+    await Promise.all([waitForTiles(finalPan, true), queryLabels(finalPan)]);
+  } else {
+    await waitForTiles(finalPan, true);
+    await queryLabels(finalPan);
+  }
+
+  await waitUntil("all tile jobs", () => activeTileJobs === 0);
+  loader.dispose();
+
+  const finishedAt = performance.now();
+  const elapsedMs = finishedAt - startedAt;
+  const animationRateHz =
+    elapsedMs > 0 ? Math.max(0, animationPhases.size - 1) / (elapsedMs / 1_000) : 0;
+  const revisionResults = revisions.map((metric) => {
+    const jobs = tileJobs.filter((job) => job.generation === metric.revision);
+    const tileLatencies = jobs.map((job) => job.latencyMs);
+    return {
+      center: metric.center.map(round),
+      initialPendingTiles: metric.initialPendingTiles,
+      label: metric.label
+        ? {
+            ...metric.label,
+            latencyMs: round(metric.label.latencyMs),
+          }
+        : null,
+      name: metric.name,
+      pendingRegions: metric.pendingRegions,
+      requestedTiles: metric.requestedTiles.size,
+      revision: metric.revision,
+      tileJobs: {
+        cancelled: jobs.filter((job) => job.outcome === "cancelled").length,
+        failed: jobs.filter((job) => job.outcome === "failed").length,
+        latencyMaxMs: tileLatencies.length > 0 ? round(Math.max(...tileLatencies)) : null,
+        latencyP50Ms: percentile(tileLatencies, 0.5),
+        latencyP95Ms: percentile(tileLatencies, 0.95),
+        rendered: jobs.filter((job) => job.outcome === "rendered").length,
+        started: jobs.length,
+      },
+      tileSettleLatencyMs:
+        metric.tileSettleLatencyMs === undefined ? null : round(metric.tileSettleLatencyMs),
+      zoom: metric.zoom,
+    };
+  });
+  const rendererDiagnostics = renderer.diagnostics();
+  const result = {
+    animation: {
+      distinctPhases: animationPhases.size,
+      heartbeatTicks,
+      maxAnimationPhaseGapMs: round(maxAnimationPhaseGapMs),
+      maxHeartbeatGapMs: round(maxHeartbeatGapMs),
+      maxMainLoopStallMs: round(maxMainLoopStallMs),
+      phaseRateHz: round(animationRateHz),
+    },
+    elapsedMs: round(elapsedMs),
+    fileBytes: file.size,
+    labelsConcurrent: renderer.labelsConcurrent,
+    loadLatencyMs: round(loadLatencyMs),
+    memory: {
+      peakRssBytes,
+      rssAfterLoadBytes,
+      rssAfterScenariosBytes: process.memoryUsage.rss(),
+      rssBeforeRendererBytes: rssBeforeRenderer,
+    },
+    progressEvents,
+    rendererStartupMs: round(rendererStartupMs),
+    revisions: revisionResults,
+    sharedBuffers: {
+      capable: capabilities.canShareArrayBuffers,
+      dataset: rendererDiagnostics.datasetBuffers,
+      semanticIndexes: rendererDiagnostics.semanticIndexBuffers,
+      sharedTransferProgressEvents,
+    },
+    stats: info.stats,
+    workerCount: {
+      tile: rendererDiagnostics.tileWorkerCount,
+      total: rendererDiagnostics.totalWorkerCount,
+    },
+    workerRestarts: {
+      progressEventsObserved: workerRestartProgressEvents,
+      restartCount: rendererDiagnostics.restartCount,
+    },
+  };
+  console.log(JSON.stringify(result, null, 2));
+
+  if (maxMainLoopStallMs > MAX_MAIN_LOOP_STALL_MS) {
+    throw Error(`Main event loop stalled for ${maxMainLoopStallMs.toFixed(1)}ms`);
+  }
+  if (maxAnimationPhaseGapMs > MAX_MAIN_LOOP_STALL_MS) {
+    throw Error(`Animation heartbeat paused for ${maxAnimationPhaseGapMs.toFixed(1)}ms`);
+  }
+  if (elapsedMs >= 2_000 && animationRateHz < MIN_ANIMATION_RATE_HZ) {
+    throw Error(`Animation heartbeat ran at only ${animationRateHz.toFixed(1)} phases/s`);
+  }
+  if (
+    capabilities.canShareArrayBuffers &&
+    rendererDiagnostics.totalWorkerCount > 1 &&
+    (!rendererDiagnostics.datasetBuffers.allShared ||
+      !rendererDiagnostics.semanticIndexBuffers.allShared)
+  ) {
+    throw Error("Multi-worker rendering did not retain shared dataset and semantic buffers");
+  }
+} finally {
+  clearInterval(heartbeat);
+  renderer.dispose();
+}

--- a/packages/cli/test/semantic-label-index.test.ts
+++ b/packages/cli/test/semantic-label-index.test.ts
@@ -1,0 +1,94 @@
+import { Osm } from "osmix";
+import { describe, expect, it, vi } from "vitest";
+
+import { SemanticLabelIndex } from "../src/semantic-label-index.ts";
+import { CliTileWorker } from "../src/tile-worker.ts";
+
+function addWay(osm: Osm, id: number, refs: number[], tags: Record<string, string>): void {
+  osm.ways.addWay({ id, refs, tags });
+}
+
+function semanticLabelOsm(id: string): Osm {
+  const osm = new Osm({ id });
+  osm.nodes.addNode({ id: 1, lon: -0.1, lat: -0.05 });
+  osm.nodes.addNode({ id: 2, lon: 0.1, lat: -0.05 });
+  osm.nodes.addNode({ id: 3, lon: 0.1, lat: 0.05 });
+  osm.nodes.addNode({ id: 4, lon: -0.1, lat: 0.05 });
+  addWay(osm, 10, [1, 2], { highway: "primary", name: "Primary Road" });
+  addWay(osm, 11, [3, 4], { highway: "residential", name: "Residential Road" });
+  addWay(osm, 12, [1, 2, 3, 4, 1], { building: "yes", name: "Named Building" });
+  addWay(osm, 13, [1, 2, 3, 4, 1], { natural: "water", name: "Relation Lake" });
+  osm.relations.addRelation({
+    id: 20,
+    members: [{ type: "way", ref: 13, role: "outer" }],
+    tags: { type: "multipolygon", natural: "water", name: "Relation Lake" },
+  });
+  osm.buildIndexes();
+  osm.ways.buildSpatialIndex();
+  osm.relations.buildSpatialIndex();
+  return osm;
+}
+
+class ExposedCliTileWorker extends CliTileWorker {
+  getOsm(id: string): Osm {
+    return this.get(id);
+  }
+}
+
+describe("SemanticLabelIndex", () => {
+  it("prefilters named entities by classification, bbox, and minimum zoom", () => {
+    const index = SemanticLabelIndex.build(semanticLabelOsm("label-index"));
+
+    expect(index.wayCount).toBe(3);
+    expect(index.relationCount).toBe(1);
+    expect(index.providers(8).ways.intersects([-1, -1, 1, 1])).toEqual([3]);
+    expect(index.providers(9).ways.intersects([-1, -1, 1, 1])).toEqual([0, 3]);
+    expect(index.providers(12).ways.intersects([-1, -1, 1, 1])).toEqual([0, 1, 3]);
+    expect(index.providers(12).ways.intersects([10, 10, 11, 11])).toEqual([]);
+    expect(index.providers(8).relations.intersects([-1, -1, 1, 1])).toEqual([0]);
+  });
+
+  it("keeps worker label queries off the raw way and relation spatial indexes", () => {
+    const osm = semanticLabelOsm("worker-semantic-labels");
+    const worker = new ExposedCliTileWorker();
+    worker.transferIn(osm.transferables());
+    const workerOsm = worker.getOsm(osm.id);
+    const waySearch = vi.spyOn(workerOsm.ways, "intersects");
+    const relationSearch = vi.spyOn(workerOsm.relations, "intersects");
+
+    const result = worker.getMapLabelCandidates(osm.id, {
+      centerX: 0.5,
+      centerY: 0.5,
+      revision: 23,
+      viewport: { width: 200, height: 100 },
+      zoom: 9,
+    });
+
+    expect(result.revision).toBe(23);
+    expect(result.candidates.some((candidate) => candidate.text === "Primary Road")).toBe(true);
+    expect(result.candidates.some((candidate) => candidate.text === "Named Building")).toBe(false);
+    expect(waySearch).not.toHaveBeenCalled();
+    expect(relationSearch).not.toHaveBeenCalled();
+    worker.delete(osm.id);
+  });
+
+  it("retains preclassification when the same shared dataset is transferred again", () => {
+    const osm = semanticLabelOsm("shared-semantic-labels");
+    const worker = new ExposedCliTileWorker();
+    worker.transferIn(osm.transferables());
+    worker.buildSemanticLabelIndex(osm.id);
+    const build = vi.spyOn(SemanticLabelIndex, "build");
+
+    worker.transferIn(osm.transferables());
+    worker.getMapLabelCandidates(osm.id, {
+      centerX: 0.5,
+      centerY: 0.5,
+      revision: 24,
+      viewport: { width: 200, height: 100 },
+      zoom: 9,
+    });
+
+    expect(build).not.toHaveBeenCalled();
+    worker.delete(osm.id);
+  });
+});

--- a/packages/cli/test/semantic-node-index.test.ts
+++ b/packages/cli/test/semantic-node-index.test.ts
@@ -1,0 +1,105 @@
+import { Osm } from "osmix";
+import { describe, expect, it, vi } from "vitest";
+
+import { SemanticNodeIndex } from "../src/semantic-node-index.ts";
+import { CliTileWorker } from "../src/tile-worker.ts";
+
+function semanticNodeOsm(id: string): Osm {
+  const osm = new Osm({ id });
+  osm.nodes.addNode({ id: 1, lon: 0, lat: 0, tags: { place: "city", name: "Center City" } });
+  osm.nodes.addNode({ id: 2, lon: 0.1, lat: 0, tags: { amenity: "cafe", name: "Cafe" } });
+  osm.nodes.addNode({ id: 3, lon: 0.2, lat: 0, tags: { amenity: "hospital" } });
+  osm.nodes.addNode({ id: 4, lon: 0.3, lat: 0, tags: { name: "Unclassified" } });
+  for (let node = 5; node < 1_005; node++) {
+    osm.nodes.addNode({ id: node, lon: 10 + node / 10_000, lat: 10 });
+  }
+  osm.buildIndexes();
+  osm.ways.buildSpatialIndex();
+  osm.relations.buildSpatialIndex();
+  return osm;
+}
+
+describe("SemanticNodeIndex", () => {
+  it("indexes only classified point features without a full node spatial index", () => {
+    const osm = semanticNodeOsm("semantic-index");
+    expect(osm.nodes.hasSpatialIndex()).toBe(false);
+    const findIndexesWithinBbox = vi.spyOn(osm.nodes, "findIndexesWithinBbox");
+
+    const index = SemanticNodeIndex.build(osm);
+
+    expect(index.size).toBe(3);
+    expect(index.labelCount).toBe(2);
+    expect(index.findIndexesWithinBbox([-1, -1, 1, 1])).toEqual([0, 1, 2]);
+    expect(index.findLabelNodes([[-1, -1, 1, 1]], 4).map((node) => node.id)).toEqual([1]);
+    expect(index.findLabelNodes([[-1, -1, 1, 1]], 14).map((node) => node.id)).toEqual([1]);
+    expect(index.findLabelNodes([[-1, -1, 1, 1]], 15).map((node) => node.id)).toEqual([1, 2]);
+    expect(
+      index
+        .findLabelNodes(
+          [
+            [-1, -1, 0.15, 1],
+            [0.05, -1, 1, 1],
+          ],
+          15,
+        )
+        .map((node) => node.id),
+    ).toEqual([1, 2]);
+    expect(findIndexesWithinBbox).not.toHaveBeenCalled();
+  });
+
+  it("returns revisioned candidates through the worker without querying node KDBush", () => {
+    const osm = semanticNodeOsm("worker-labels");
+    const worker = new CliTileWorker();
+    worker.transferIn(osm.transferables());
+
+    const result = worker.getMapLabelCandidates(osm.id, {
+      centerX: 0.5,
+      centerY: 0.5,
+      revision: 17,
+      viewport: { width: 100, height: 60 },
+      zoom: 4,
+    });
+
+    expect(result.revision).toBe(17);
+    expect(result.candidates).toHaveLength(1);
+    expect(result.candidates[0]).toMatchObject({
+      kind: "place",
+      stableKey: "node:1:point",
+      text: "Center City",
+    });
+    worker.delete(osm.id);
+  });
+
+  it("retains a semantic index when the same shared dataset is transferred again", () => {
+    const osm = semanticNodeOsm("worker-shared-labels");
+    const worker = new CliTileWorker();
+    worker.transferIn(osm.transferables());
+    worker.buildSemanticNodeIndex(osm.id);
+    const build = vi.spyOn(SemanticNodeIndex, "build");
+
+    worker.transferIn(osm.transferables());
+    worker.getMapLabelCandidates(osm.id, {
+      centerX: 0.5,
+      centerY: 0.5,
+      revision: 1,
+      viewport: { width: 100, height: 60 },
+      zoom: 4,
+    });
+
+    expect(build).not.toHaveBeenCalled();
+    worker.delete(osm.id);
+  });
+
+  it("shares compact point geometry without rebuilding it in tile workers", () => {
+    const osm = semanticNodeOsm("shared-point-geometry");
+    const original = SemanticNodeIndex.build(osm);
+    const transferables = original.transferables();
+    const restored = SemanticNodeIndex.fromTransferables(transferables);
+
+    expect(restored.findIndexesWithinBbox([-1, -1, 1, 1]).sort((a, b) => a - b)).toEqual([0, 1, 2]);
+    expect(restored.transferables().indexes).toBe(transferables.indexes);
+    expect(restored.transferables().featureIndex.spatialIndex).toBe(
+      transferables.featureIndex.spatialIndex,
+    );
+  });
+});

--- a/packages/cli/test/semantic-render-index.test.ts
+++ b/packages/cli/test/semantic-render-index.test.ts
@@ -1,0 +1,98 @@
+import { pointToTileFraction } from "@osmix/geo/tile";
+import { ShortbreadFeatureIndex } from "@osmix/shortbread";
+import { getFixtureFileReadStream, PBFs } from "@osmix/test-utils";
+import { fromPbf, Osm, type GeoBbox2D, type Tile } from "osmix";
+import { describe, expect, it, vi } from "vitest";
+
+import { SemanticRenderIndex } from "../src/semantic-render-index.ts";
+import { drawStyledMapTile } from "../src/styled-tile.ts";
+import { CliTileWorker } from "../src/tile-worker.ts";
+
+function renderIndexOsm(): Osm {
+  const osm = new Osm();
+  osm.nodes.addNode({ id: 1, lon: -0.1, lat: -0.1 });
+  osm.nodes.addNode({ id: 2, lon: 0.1, lat: -0.1 });
+  osm.nodes.addNode({ id: 3, lon: 0.1, lat: 0.1 });
+  osm.nodes.addNode({ id: 4, lon: -0.1, lat: 0.1 });
+  osm.ways.addWay({ id: 10, refs: [1, 2], tags: { highway: "primary" } });
+  osm.ways.addWay({ id: 11, refs: [2, 3], tags: { highway: "footway" } });
+  osm.ways.addWay({ id: 12, refs: [1, 2, 3, 4, 1], tags: { building: "yes" } });
+  osm.ways.addWay({ id: 13, refs: [3, 4] });
+  osm.relations.addRelation({
+    id: 20,
+    members: [{ type: "way", ref: 10, role: "" }],
+    tags: { boundary: "administrative", admin_level: "2", type: "boundary" },
+  });
+  osm.buildIndexes();
+  osm.ways.buildSpatialIndex();
+  osm.relations.buildSpatialIndex();
+  return osm;
+}
+
+describe("SemanticRenderIndex", () => {
+  it("filters geometry spatial searches using compact minimum-zoom bitsets", () => {
+    const osm = renderIndexOsm();
+    const index = SemanticRenderIndex.build(osm);
+    const bbox: GeoBbox2D = [-1, -1, 1, 1];
+    const waySearch = vi.spyOn(osm.ways, "intersects");
+    const relationSearch = vi.spyOn(osm.relations, "intersects");
+
+    expect(index.ways(osm.ways, 8).intersects(bbox)).toEqual([0]);
+    expect(index.ways(osm.ways, 13).intersects(bbox)).toEqual([0, 2]);
+    expect(index.ways(osm.ways, 14).intersects(bbox)).toEqual([0, 1, 2]);
+    expect(index.relations(osm.relations, 3).intersects(bbox)).toEqual([]);
+    // The boundary relation has area geometry but no Shortbread polygon classification.
+    expect(index.relations(osm.relations, 4).intersects(bbox)).toEqual([]);
+    expect(waySearch).not.toHaveBeenCalled();
+    expect(relationSearch).not.toHaveBeenCalled();
+  });
+
+  it("reuses shared bitset buffers in tile workers", () => {
+    const osm = renderIndexOsm();
+    const original = SemanticRenderIndex.build(osm);
+    const transferables = original.transferables();
+    const restored = SemanticRenderIndex.fromTransferables(transferables);
+
+    expect(restored.ways(osm.ways, 8).intersects([-1, -1, 1, 1])).toEqual([0]);
+    expect(restored.transferables().ways).toBe(transferables.ways);
+    expect(restored.transferables().relations).toBe(transferables.relations);
+  });
+
+  it("shares one Shortbread candidate index across worker-owned overlays", () => {
+    const osm = renderIndexOsm();
+    const source = new CliTileWorker();
+    source.transferIn(osm.transferables());
+    source.buildShortbreadFeatureIndex(osm.id);
+    const transferables = source.getShortbreadFeatureIndexTransferables(osm.id);
+
+    const target = new CliTileWorker();
+    target.transferIn(osm.transferables());
+    target.setShortbreadFeatureIndex(osm.id, osm.contentHash(), transferables);
+    const build = vi.spyOn(ShortbreadFeatureIndex, "build");
+    target.buildSemanticRenderIndex(osm.id);
+    target.buildSemanticNodeIndex(osm.id);
+    target.buildSemanticLabelIndex(osm.id);
+
+    expect(build).not.toHaveBeenCalled();
+    const restored = target.getShortbreadFeatureIndexTransferables(osm.id);
+    expect(restored.entityIndexes).toBe(transferables.entityIndexes);
+    expect(restored.spatialIndex).toBe(transferables.spatialIndex);
+    source.delete(osm.id);
+    target.delete(osm.id);
+  });
+
+  it("preserves fixture-backed styled output across overview and detailed zooms", async () => {
+    const osm = await fromPbf(getFixtureFileReadStream(PBFs["monaco"]!.url));
+    const index = SemanticRenderIndex.build(osm);
+    for (const zoom of [10, 14]) {
+      const [tileX, tileY] = pointToTileFraction(7.42, 43.74, zoom);
+      const tile: Tile = [Math.floor(tileX), Math.floor(tileY), zoom];
+      const expected = drawStyledMapTile(osm, tile, 64).imageData;
+      const actual = drawStyledMapTile(osm, tile, 64, undefined, {
+        relations: index.relations(osm.relations, zoom),
+        ways: index.ways(osm.ways, zoom),
+      }).imageData;
+      expect(actual).toEqual(expected);
+    }
+  });
+});

--- a/packages/cli/test/styled-tile.test.ts
+++ b/packages/cli/test/styled-tile.test.ts
@@ -1,0 +1,353 @@
+import { pointToTileFraction } from "@osmix/geo/tile";
+import { getFixtureFileReadStream, PBFs } from "@osmix/test-utils";
+import { fromPbf, Osm, OsmixRasterTile, type LonLat, type Rgba, type Tile, type XY } from "osmix";
+import { describe, expect, it, vi } from "vitest";
+
+import { DARK_MAP_COLORS } from "../src/map-style.ts";
+import { drawStyledMapTile, drawStyledMapTileAsync } from "../src/styled-tile.ts";
+
+function tileAt(lon: number, lat: number, zoom: number): Tile {
+  const [x, y] = pointToTileFraction(lon, lat, zoom);
+  return [Math.floor(x), Math.floor(y), zoom];
+}
+
+function addWayAtPixels(
+  osm: Osm,
+  projector: OsmixRasterTile,
+  id: number,
+  pixels: XY[],
+  tags: Record<string, string>,
+): void {
+  const refs: number[] = [];
+  for (const [index, pixel] of pixels.entries()) {
+    if (index === pixels.length - 1 && pixel[0] === pixels[0]?.[0] && pixel[1] === pixels[0]?.[1]) {
+      refs.push(refs[0]!);
+      continue;
+    }
+    const nodeId = id * 100 + index;
+    const [lon, lat] = projector.tilePxToLonLat(pixel);
+    osm.nodes.addNode({ id: nodeId, lon, lat });
+    refs.push(nodeId);
+  }
+  osm.ways.addWay({ id, refs, tags });
+}
+
+function pixel(tile: OsmixRasterTile, xy: XY): number[] {
+  const index = tile.getIndex(xy);
+  return Array.from(tile.imageData.slice(index, index + 4));
+}
+
+function countColor(tile: OsmixRasterTile, color: Rgba): number {
+  let count = 0;
+  for (let offset = 0; offset < tile.imageData.length; offset += 4) {
+    if (
+      tile.imageData[offset] === color[0] &&
+      tile.imageData[offset + 1] === color[1] &&
+      tile.imageData[offset + 2] === color[2]
+    ) {
+      count++;
+    }
+  }
+  return count;
+}
+
+function buildNonNodeSpatialIndexes(osm: Osm): void {
+  osm.buildIndexes();
+  osm.ways.buildSpatialIndex();
+  osm.relations.buildSpatialIndex();
+}
+
+describe("drawStyledMapTile", () => {
+  it("draws semantic areas, cased roads, buildings, and points in layer order", () => {
+    const tileIndex = tileAt(0, 0, 14);
+    const tileSize = 128;
+    const projector = new OsmixRasterTile({ tile: tileIndex, tileSize });
+    const osm = new Osm();
+
+    addWayAtPixels(
+      osm,
+      projector,
+      2,
+      [
+        [10, 10],
+        [50, 10],
+        [50, 50],
+        [10, 50],
+        [10, 10],
+      ],
+      {
+        natural: "water",
+      },
+    );
+    addWayAtPixels(
+      osm,
+      projector,
+      3,
+      [
+        [70, 70],
+        [100, 70],
+        [100, 100],
+        [70, 100],
+        [70, 70],
+      ],
+      {
+        building: "yes",
+      },
+    );
+    addWayAtPixels(
+      osm,
+      projector,
+      5,
+      [
+        [10, 70],
+        [50, 70],
+        [50, 110],
+        [10, 110],
+        [10, 70],
+      ],
+      {
+        natural: "wood",
+      },
+    );
+    addWayAtPixels(
+      osm,
+      projector,
+      4,
+      [
+        [4, 30],
+        [124, 30],
+      ],
+      { highway: "primary" },
+    );
+    const hospital: LonLat = projector.tilePxToLonLat([110, 110]);
+    osm.nodes.addNode({
+      id: 999,
+      lon: hospital[0],
+      lat: hospital[1],
+      tags: { amenity: "hospital" },
+    });
+    osm.buildIndexes();
+    osm.buildSpatialIndexes();
+
+    const rendered = drawStyledMapTile(osm, tileIndex, tileSize);
+
+    expect(countColor(rendered, DARK_MAP_COLORS.water)).toBeGreaterThan(0);
+    expect(countColor(rendered, DARK_MAP_COLORS.vegetation)).toBeGreaterThan(0);
+    expect(pixel(rendered, [80, 80])).toEqual(DARK_MAP_COLORS.building);
+    expect(pixel(rendered, [60, 30])).toEqual(DARK_MAP_COLORS.primary);
+    expect(pixel(rendered, [60, 28])).toEqual(DARK_MAP_COLORS.roadCasing);
+    expect(countColor(rendered, DARK_MAP_COLORS.medical)).toBe(5);
+  });
+
+  it("adds minor road detail as the map zooms in", () => {
+    const osm = new Osm();
+    const closeTile = tileAt(0, 0, 14);
+    const closeProjector = new OsmixRasterTile({ tile: closeTile, tileSize: 64 });
+    addWayAtPixels(
+      osm,
+      closeProjector,
+      1,
+      [
+        [4, 32],
+        [60, 32],
+      ],
+      { highway: "service" },
+    );
+    osm.buildIndexes();
+    osm.buildSpatialIndexes();
+
+    const hiddenTile = tileAt(0, 0, 9);
+    const overviewTile = tileAt(0, 0, 10);
+    const hidden = drawStyledMapTile(osm, hiddenTile, 64);
+    const overview = drawStyledMapTile(osm, overviewTile, 64);
+    const close = drawStyledMapTile(osm, closeTile, 64);
+
+    expect(countColor(hidden, DARK_MAP_COLORS.service)).toBe(0);
+    expect(countColor(overview, DARK_MAP_COLORS.service)).toBeGreaterThan(0);
+    expect(countColor(close, DARK_MAP_COLORS.service)).toBeGreaterThan(0);
+  });
+
+  it("filters hidden ways before retrieving their coordinates", () => {
+    const osm = new Osm();
+    const closeTile = tileAt(0, 0, 14);
+    const projector = new OsmixRasterTile({ tile: closeTile, tileSize: 64 });
+    addWayAtPixels(
+      osm,
+      projector,
+      1,
+      [
+        [4, 32],
+        [60, 32],
+      ],
+      { highway: "service" },
+    );
+    osm.buildIndexes();
+    osm.buildSpatialIndexes();
+    const getFullEntity = vi.spyOn(osm.ways, "getFullEntity");
+    const getCoordinates = vi.spyOn(osm.ways, "getCoordinates");
+
+    drawStyledMapTile(osm, tileAt(0, 0, 9), 64);
+    expect(getFullEntity).not.toHaveBeenCalled();
+    expect(getCoordinates).not.toHaveBeenCalled();
+
+    drawStyledMapTile(osm, tileAt(0, 0, 10), 64);
+    expect(getFullEntity).toHaveBeenCalledTimes(1);
+    expect(getCoordinates).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not require a node spatial index below the semantic point zoom", () => {
+    const tileIndex = tileAt(0, 0, 13);
+    const projector = new OsmixRasterTile({ tile: tileIndex, tileSize: 64 });
+    const osm = new Osm();
+    const hospital = projector.tilePxToLonLat([32, 32]);
+    osm.nodes.addNode({
+      id: 1,
+      lon: hospital[0],
+      lat: hospital[1],
+      tags: { amenity: "hospital" },
+    });
+    buildNonNodeSpatialIndexes(osm);
+    const findNodes = vi.spyOn(osm.nodes, "findIndexesWithinBbox");
+
+    expect(osm.nodes.hasSpatialIndex()).toBe(false);
+    expect(() => drawStyledMapTile(osm, tileIndex, 64)).not.toThrow();
+    expect(findNodes).not.toHaveBeenCalled();
+  });
+
+  it("uses a compact node-index provider for close-zoom semantic points", () => {
+    const tileIndex = tileAt(0, 0, 14);
+    const projector = new OsmixRasterTile({ tile: tileIndex, tileSize: 64 });
+    const osm = new Osm();
+    const hospital = projector.tilePxToLonLat([32, 32]);
+    osm.nodes.addNode({
+      id: 1,
+      lon: hospital[0],
+      lat: hospital[1],
+      tags: { amenity: "hospital" },
+    });
+    buildNonNodeSpatialIndexes(osm);
+    const nodeIndexProvider = { findIndexesWithinBbox: vi.fn(() => [0]) };
+
+    const rendered = drawStyledMapTile(osm, tileIndex, 64, nodeIndexProvider);
+
+    expect(osm.nodes.hasSpatialIndex()).toBe(false);
+    expect(nodeIndexProvider.findIndexesWithinBbox).toHaveBeenCalledTimes(1);
+    expect(countColor(rendered, DARK_MAP_COLORS.medical)).toBe(5);
+  });
+
+  it("keeps roads that are members of unclassified route relations", () => {
+    const tileIndex = tileAt(0, 0, 14);
+    const projector = new OsmixRasterTile({ tile: tileIndex, tileSize: 64 });
+    const osm = new Osm();
+    addWayAtPixels(
+      osm,
+      projector,
+      1,
+      [
+        [4, 32],
+        [60, 32],
+      ],
+      { highway: "secondary" },
+    );
+    osm.relations.addRelation({
+      id: 2,
+      members: [{ type: "way", ref: 1, role: "" }],
+      tags: { type: "route", route: "hiking" },
+    });
+    osm.buildIndexes();
+    osm.buildSpatialIndexes();
+    const getRelation = vi.spyOn(osm.relations, "getByIndex");
+    const getRelationGeometry = vi.spyOn(osm.relations, "getRelationGeometry");
+
+    const rendered = drawStyledMapTile(osm, tileIndex, 64);
+    expect(countColor(rendered, DARK_MAP_COLORS.secondary)).toBeGreaterThan(0);
+    expect(getRelation).not.toHaveBeenCalled();
+    expect(getRelationGeometry).not.toHaveBeenCalled();
+  });
+
+  it("preserves synchronous output while the cooperative renderer yields in chunks", async () => {
+    const tileIndex = tileAt(0, 0, 14);
+    const projector = new OsmixRasterTile({ tile: tileIndex, tileSize: 64 });
+    const osm = new Osm();
+    addWayAtPixels(
+      osm,
+      projector,
+      1,
+      [
+        [4, 32],
+        [60, 32],
+      ],
+      { highway: "primary" },
+    );
+    osm.buildIndexes();
+    osm.buildSpatialIndexes();
+    let yields = 0;
+
+    const synchronous = drawStyledMapTile(osm, tileIndex, 64);
+    const cooperative = await drawStyledMapTileAsync(
+      osm,
+      tileIndex,
+      64,
+      undefined,
+      {},
+      () => false,
+      {
+        chunkBudgetMs: 0,
+        yieldToEventLoop: () => {
+          yields++;
+          return Promise.resolve();
+        },
+      },
+    );
+
+    expect(yields).toBeGreaterThan(0);
+    expect(cooperative.imageData).toEqual(synchronous.imageData);
+  });
+
+  it("yields a macrotask so a non-shared cancellation message can stop stale work", async () => {
+    const tileIndex = tileAt(0, 0, 14);
+    const projector = new OsmixRasterTile({ tile: tileIndex, tileSize: 64 });
+    const osm = new Osm();
+    addWayAtPixels(
+      osm,
+      projector,
+      1,
+      [
+        [4, 32],
+        [60, 32],
+      ],
+      { highway: "primary" },
+    );
+    osm.buildIndexes();
+    osm.buildSpatialIndexes();
+    let cancelled = false;
+    setTimeout(() => {
+      cancelled = true;
+    }, 0);
+
+    const rendered = await drawStyledMapTileAsync(
+      osm,
+      tileIndex,
+      64,
+      undefined,
+      {},
+      () => cancelled,
+      { chunkBudgetMs: 0 },
+    );
+
+    expect(cancelled).toBe(true);
+    expect(countColor(rendered, DARK_MAP_COLORS.primary)).toBe(0);
+  });
+
+  it("renders semantic detail from the Monaco PBF fixture", async () => {
+    const osm = await fromPbf(getFixtureFileReadStream(PBFs["monaco"]!.url));
+    const streetTile = drawStyledMapTile(osm, [17_059, 11_948, 15], 128);
+    const buildingTile = drawStyledMapTile(osm, [68_236, 47_796, 17], 256);
+
+    expect(countColor(streetTile, DARK_MAP_COLORS.primary)).toBeGreaterThan(0);
+    expect(countColor(streetTile, DARK_MAP_COLORS.residential)).toBeGreaterThan(0);
+    expect(countColor(streetTile, DARK_MAP_COLORS.path)).toBeGreaterThan(0);
+    expect(countColor(streetTile, DARK_MAP_COLORS.transit)).toBeGreaterThan(0);
+    expect(countColor(buildingTile, DARK_MAP_COLORS.building)).toBeGreaterThan(0);
+  });
+});

--- a/packages/cli/test/tile-renderer.test.ts
+++ b/packages/cli/test/tile-renderer.test.ts
@@ -1,0 +1,174 @@
+import { execFile } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+import { GenerationGate } from "@osmix/shared/generation-gate";
+import { Osm, OsmixRasterTile, type Tile } from "osmix";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  createStyledTileRenderer,
+  selectTileWorkerCount,
+  tileWorkerUrl,
+} from "../src/tile-renderer.ts";
+import { CliTileWorker } from "../src/tile-worker.ts";
+
+const execFileAsync = promisify(execFile);
+
+function indexedOsm(id: string): Osm {
+  const osm = new Osm({ id });
+  osm.buildIndexes();
+  osm.buildSpatialIndexes();
+  return osm;
+}
+
+function denselyIndexedOsm(id: string, tile: Tile, wayCount: number): Osm {
+  const osm = new Osm({ id });
+  const projector = new OsmixRasterTile({ tile, tileSize: 256 });
+  for (let index = 0; index < wayCount; index++) {
+    const y = 1 + (index % 254);
+    const from = projector.tilePxToLonLat([1, y]);
+    const to = projector.tilePxToLonLat([254, y]);
+    const firstNodeId = index * 2 + 1;
+    osm.nodes.addNode({ id: firstNodeId, lat: from[1], lon: from[0] });
+    osm.nodes.addNode({ id: firstNodeId + 1, lat: to[1], lon: to[0] });
+    osm.ways.addWay({
+      id: index + 1,
+      refs: [firstNodeId, firstNodeId + 1],
+      tags: { highway: "primary" },
+    });
+  }
+  osm.buildIndexes();
+  osm.buildSpatialIndexes();
+  return osm;
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("CLI tile workers", () => {
+  it("uses shared worker-count selection while reserving one logical core", () => {
+    expect(selectTileWorkerCount(1)).toBe(1);
+    expect(selectTileWorkerCount(2)).toBe(1);
+    expect(selectTileWorkerCount(3)).toBe(2);
+    expect(selectTileWorkerCount(8)).toBe(4);
+  });
+
+  it("resolves a source or built worker beside the renderer module", () => {
+    expect(tileWorkerUrl().pathname).toMatch(/\/cli\.worker\.(?:ts|js)$/);
+    expect(tileWorkerUrl("file:///app/tile-renderer.ts?worker_file&type=module").pathname).toBe(
+      "/app/cli.worker.ts",
+    );
+    expect(tileWorkerUrl("file:///app/tile-renderer.js#bundled").pathname).toBe(
+      "/app/cli.worker.js",
+    );
+  });
+
+  it("renders styled pixel buffers through the custom worker method", () => {
+    const osm = indexedOsm("direct-worker");
+    const worker = new CliTileWorker();
+    worker.transferIn(osm.transferables());
+
+    const data = worker.getStyledRasterTile(osm.id, [0, 0, 0]);
+
+    expect(data).toBeInstanceOf(Uint8ClampedArray);
+    if (!data) throw Error("Expected a completed tile");
+    expect(data.byteLength).toBe(256 * 256 * 4);
+    worker.delete(osm.id);
+  });
+
+  it("cooperatively cancels stale shared-buffer tile generations", () => {
+    const osm = indexedOsm("cancelled-worker");
+    const worker = new CliTileWorker();
+    worker.transferIn(osm.transferables());
+    const cancellation = GenerationGate.create({ initialGeneration: 4, shared: true });
+
+    expect(
+      worker.getStyledRasterTile(osm.id, [0, 0, 0], 3, cancellation.transferables()),
+    ).toBeNull();
+    expect(
+      worker.getStyledRasterTile(osm.id, [0, 0, 0], 4, cancellation.transferables()),
+    ).toBeInstanceOf(Uint8ClampedArray);
+    worker.delete(osm.id);
+  });
+
+  it("cooperatively cancels stale generations without shared buffers", async () => {
+    const osm = indexedOsm("message-cancelled-worker");
+    const worker = new CliTileWorker();
+    worker.transferIn(osm.transferables());
+    worker.cancelTilesBefore(4);
+
+    await expect(worker.getStyledRasterTileCooperatively(osm.id, [0, 0, 0], 3)).resolves.toBeNull();
+    await expect(
+      worker.getStyledRasterTileCooperatively(osm.id, [0, 0, 0], 4),
+    ).resolves.toBeInstanceOf(Uint8ClampedArray);
+    worker.delete(osm.id);
+  });
+
+  it("services a cancellation update while a non-shared tile is rendering", async () => {
+    const tile: Tile = [4_096, 4_096, 13];
+    const osm = denselyIndexedOsm("yielded-message-cancel-worker", tile, 2_000);
+    const worker = new CliTileWorker();
+    worker.transferIn(osm.transferables());
+    setTimeout(() => worker.cancelTilesBefore(2), 0);
+
+    await expect(worker.getStyledRasterTileCooperatively(osm.id, tile, 1)).resolves.toBeNull();
+    worker.delete(osm.id);
+  });
+
+  it("returns dataset metadata rather than a main-thread Osm instance", async () => {
+    const fixture = fileURLToPath(new URL("../../../fixtures/monaco.pbf", import.meta.url));
+    const worker = new CliTileWorker();
+    const info = await worker.fromPbfFile(fixture, {
+      id: "metadata-worker",
+      buildSpatialIndexes: ["way", "relation"],
+    });
+
+    expect(info).toMatchObject({
+      id: "metadata-worker",
+      bbox: expect.arrayContaining([expect.any(Number)]),
+      stats: {
+        nodes: expect.any(Number),
+        relations: expect.any(Number),
+        ways: expect.any(Number),
+      },
+    });
+    expect(info.stats.nodes).toBeGreaterThan(0);
+    expect(info).not.toHaveProperty("nodes");
+    worker.delete(info.id);
+  });
+
+  it("rejects runtimes without workers instead of falling back to local rendering", async () => {
+    vi.stubGlobal("Worker", undefined);
+
+    await expect(createStyledTileRenderer()).rejects.toThrow(
+      "requires Web Worker support for non-blocking rendering",
+    );
+  });
+
+  it("renders concurrently in Bun while the main-thread timer advances", async () => {
+    const smokeTest = fileURLToPath(new URL("./worker-smoke.ts", import.meta.url));
+    const { stdout } = await execFileAsync("bun", [smokeTest]);
+    const lastLine = stdout.trim().split("\n").at(-1);
+    const result = JSON.parse(lastLine ?? "null") as {
+      byteLengths: number[];
+      datasetId: string;
+      datasetNodes: number;
+      hardwareConcurrency: number;
+      maxTimerLagMs: number;
+      mode: string;
+      progressEvents: number;
+      timerTicks: number;
+      workerCount: number;
+    };
+
+    expect(result.mode).toBe("workers");
+    const totalWorkers = selectTileWorkerCount(result.hardwareConcurrency);
+    expect(result.workerCount).toBe(totalWorkers > 1 ? totalWorkers - 1 : 1);
+    expect(result.progressEvents).toBeGreaterThan(0);
+    expect(result.datasetId).toBe("worker-smoke");
+    expect(result.datasetNodes).toBeGreaterThan(0);
+    expect(result.timerTicks).toBeGreaterThan(0);
+    expect(result.maxTimerLagMs).toBeLessThan(250);
+    expect(result.byteLengths).toEqual(Array(4).fill(256 * 256 * 4));
+  }, 30_000);
+});

--- a/packages/cli/test/viewer-animation-smoke.ts
+++ b/packages/cli/test/viewer-animation-smoke.ts
@@ -1,0 +1,228 @@
+import { createTestRenderer } from "@opentui/core/testing";
+import type { OsmInfo } from "osmix";
+
+import type { StyledTileRenderer } from "../src/tile-renderer.ts";
+import { animationPhase, TerminalMapViewer } from "../src/viewer.ts";
+
+const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"] as const;
+const SPINNER_PATTERN = /([⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]) (?:Rendering|Loading)/;
+const TILE_PIXEL_BYTES = 256 * 256 * 4;
+
+const info: OsmInfo = {
+  id: "test-map",
+  bbox: [7.4, 43.7, 7.5, 43.8],
+  header: { optional_features: [], required_features: [] },
+  stats: { nodes: 1_000, ways: 100, relations: 10 },
+};
+
+function delay(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+function never<T>(): Promise<T> {
+  return new Promise<T>(() => undefined);
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 1_000): Promise<number> {
+  const startedAt = performance.now();
+  while (!predicate()) {
+    if (performance.now() - startedAt > timeoutMs) throw Error("Timed out waiting for condition");
+    await delay(5);
+  }
+  return performance.now() - startedAt;
+}
+
+function maximumGap(timestamps: number[]): number {
+  let maximum = 0;
+  for (let index = 1; index < timestamps.length; index++) {
+    maximum = Math.max(maximum, timestamps[index]! - timestamps[index - 1]!);
+  }
+  return maximum;
+}
+
+let renderCalls = 0;
+let labelCalls = 0;
+let staticCompositions = 0;
+const pending = await createTestRenderer({
+  width: 48,
+  height: 8,
+  targetFps: 10,
+  maxFps: 30,
+});
+const pendingTileRenderer: StyledTileRenderer = {
+  labelsConcurrent: false,
+  mode: "workers",
+  workerCount: 1,
+  cancelBefore: () => undefined,
+  diagnostics: () => ({
+    datasetBuffers: { allShared: false, referenceCount: 0, uniqueCount: 0 },
+    restartCount: 0,
+    semanticIndexBuffers: { allShared: false, referenceCount: 0, uniqueCount: 0 },
+    tileWorkerCount: 1,
+    totalWorkerCount: 1,
+  }),
+  dispose: () => undefined,
+  loadPbfFile: () => never(),
+  queryLabels: () => {
+    labelCalls++;
+    return never();
+  },
+  renderTile: () => {
+    renderCalls++;
+    return never();
+  },
+};
+const pendingViewer = new TerminalMapViewer(
+  pending.renderer,
+  "regional.pbf",
+  () => performance.now(),
+  { onStaticCompose: () => staticCompositions++ },
+);
+pendingViewer.setDataset(info, pendingTileRenderer);
+
+const spinnerPhases: string[] = [];
+const shimmerFrames: string[] = [];
+const animationTimestamps: number[] = [];
+const recordAnimationFrame = () => {
+  const frame = pending.captureCharFrame();
+  const spinner = frame.match(SPINNER_PATTERN)?.[1];
+  if (!spinner) return;
+  spinnerPhases.push(spinner);
+  shimmerFrames.push(JSON.stringify(pending.captureSpans().lines.slice(0, -1)));
+  animationTimestamps.push(performance.now());
+};
+pending.renderer.on("frame", recordAnimationFrame);
+await waitFor(() => renderCalls > 0 && animationTimestamps.length > 0);
+spinnerPhases.length = 0;
+shimmerFrames.length = 0;
+animationTimestamps.length = 0;
+const staticCompositionsBeforeAnimation = staticCompositions;
+const renderCallsBeforeAnimation = renderCalls;
+await delay(1_100);
+pending.renderer.off("frame", recordAnimationFrame);
+const staticCompositionsAfterAnimation = staticCompositions;
+
+const centerBeforeInput = pendingViewer.camera.centerX;
+const inputStartedAt = performance.now();
+pending.mockInput.pressArrow("right");
+const inputLatencyMs = await waitFor(() => pendingViewer.camera.centerX !== centerBeforeInput);
+const inputHandledAt = performance.now() - inputStartedAt;
+
+const zoomBeforeInput = pendingViewer.camera.zoom;
+const zoomStartedAt = performance.now();
+pending.mockInput.pressKey("+");
+const zoomLatencyMs = await waitFor(() => pendingViewer.camera.zoom !== zoomBeforeInput);
+const zoomHandledAt = performance.now() - zoomStartedAt;
+
+const resizeStartedAt = performance.now();
+pending.resize(60, 10);
+const resizeLatencyMs = await waitFor(
+  () =>
+    pendingViewer.canvas.frameBuffer.width === 60 && pendingViewer.canvas.frameBuffer.height === 10,
+);
+const resizeHandledAt = performance.now() - resizeStartedAt;
+
+const quitStartedAt = performance.now();
+pending.mockInput.pressKey("q");
+const quitLatencyMs = await waitFor(() => pending.renderer.isDestroyed);
+const quitHandledAt = performance.now() - quitStartedAt;
+
+const backpressured = await createTestRenderer({
+  width: 48,
+  height: 8,
+  targetFps: 10,
+  maxFps: 30,
+});
+type NativeRenderStatus = "backpressured" | "blocked" | "failed" | "rendered" | "retryable-skip";
+const rendererInternals = backpressured.renderer as unknown as {
+  renderNative: () => NativeRenderStatus;
+};
+const renderNative = rendererInternals.renderNative.bind(backpressured.renderer);
+let acceptNativeFrames = false;
+rendererInternals.renderNative = () => (acceptNativeFrames ? renderNative() : "backpressured");
+
+let backpressureFrameEvents = 0;
+let backpressureLabelCalls = 0;
+let backpressureRenderCalls = 0;
+let backpressureStaticCompositions = 0;
+let completedTiles = 0;
+backpressured.renderer.on("frame", () => backpressureFrameEvents++);
+const backpressureTileRenderer: StyledTileRenderer = {
+  labelsConcurrent: false,
+  mode: "workers",
+  workerCount: 1,
+  cancelBefore: () => undefined,
+  diagnostics: () => ({
+    datasetBuffers: { allShared: false, referenceCount: 0, uniqueCount: 0 },
+    restartCount: 0,
+    semanticIndexBuffers: { allShared: false, referenceCount: 0, uniqueCount: 0 },
+    tileWorkerCount: 1,
+    totalWorkerCount: 1,
+  }),
+  dispose: () => undefined,
+  loadPbfFile: () => never(),
+  queryLabels: () => {
+    backpressureLabelCalls++;
+    return never();
+  },
+  renderTile: async () => {
+    backpressureRenderCalls++;
+    await delay(20);
+    completedTiles++;
+    return { data: new Uint8ClampedArray(TILE_PIXEL_BYTES) };
+  },
+};
+const backpressureViewer = new TerminalMapViewer(
+  backpressured.renderer,
+  "regional.pbf",
+  () => performance.now(),
+  { onStaticCompose: () => backpressureStaticCompositions++ },
+);
+backpressureViewer.setDataset(info, backpressureTileRenderer);
+await delay(450);
+const frameEventsWhileBackpressured = backpressureFrameEvents;
+
+const resumedFrame = new Promise<{ frame: string; timestamp: number }>((resolve) => {
+  backpressured.renderer.once("frame", () =>
+    resolve({ frame: backpressured.captureCharFrame(), timestamp: performance.now() }),
+  );
+});
+acceptNativeFrames = true;
+backpressured.renderer.requestRender();
+const resumed = await Promise.race([
+  resumedFrame,
+  delay(1_000).then(() => {
+    throw Error("Timed out waiting for output to resume");
+  }),
+]);
+const resumedSpinner = resumed.frame.match(SPINNER_PATTERN)?.[1];
+const expectedSpinner = SPINNER_FRAMES[animationPhase(resumed.timestamp) % SPINNER_FRAMES.length];
+const previousSpinner =
+  SPINNER_FRAMES[
+    (animationPhase(resumed.timestamp) - 1 + SPINNER_FRAMES.length) % SPINNER_FRAMES.length
+  ];
+backpressured.renderer.destroy();
+
+console.log(
+  JSON.stringify({
+    animationFrameCount: animationTimestamps.length,
+    backpressureFrameEvents: frameEventsWhileBackpressured,
+    backpressureLabelCalls,
+    backpressureRenderCalls,
+    backpressureStaticCompositions,
+    completedTiles,
+    distinctShimmerFrames: new Set(shimmerFrames).size,
+    distinctSpinnerPhases: new Set(spinnerPhases).size,
+    finalRenderCalls: renderCalls,
+    inputHandled: inputHandledAt < 250 && inputLatencyMs < 250,
+    labelCalls,
+    maxAnimationGapMs: maximumGap(animationTimestamps),
+    quitHandled: quitHandledAt < 250 && quitLatencyMs < 250,
+    renderCallsBeforeAnimation,
+    resizeHandled: resizeHandledAt < 250 && resizeLatencyMs < 250,
+    resumedAtClockPhase: resumedSpinner === expectedSpinner || resumedSpinner === previousSpinner,
+    staticCompositionsAfterAnimation,
+    staticCompositionsBeforeAnimation,
+    zoomHandled: zoomHandledAt < 250 && zoomLatencyMs < 250,
+  }),
+);

--- a/packages/cli/test/viewer.test.ts
+++ b/packages/cli/test/viewer.test.ts
@@ -1,0 +1,78 @@
+import { execFile } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+import { describe, expect, it } from "vitest";
+
+import { animationPhase, formatRenderingModeStatus, viewerShouldAnimate } from "../src/viewer.ts";
+
+const execFileAsync = promisify(execFile);
+
+describe("viewer loading animation lifecycle", () => {
+  it("animates while parsing, labels, or tiles are pending and stops otherwise", () => {
+    expect(viewerShouldAnimate("loading", 0)).toBe(true);
+    expect(viewerShouldAnimate("ready", 2)).toBe(true);
+    expect(viewerShouldAnimate("ready", 0, true)).toBe(true);
+    expect(viewerShouldAnimate("ready", 0)).toBe(false);
+    expect(viewerShouldAnimate("error", 2)).toBe(false);
+  });
+
+  it("derives phases from the clock instead of successful frame events", () => {
+    expect(animationPhase(0)).toBe(0);
+    expect(animationPhase(99)).toBe(0);
+    expect(animationPhase(100)).toBe(1);
+    expect(animationPhase(950)).toBe(9);
+  });
+
+  it("keeps OpenTUI animation independent from tile and label scheduling", async () => {
+    const smokeTest = fileURLToPath(new URL("./viewer-animation-smoke.ts", import.meta.url));
+    const { stdout } = await execFileAsync("bun", [smokeTest]);
+    const result = JSON.parse(stdout.trim().split("\n").at(-1) ?? "null") as {
+      animationFrameCount: number;
+      backpressureFrameEvents: number;
+      backpressureLabelCalls: number;
+      backpressureRenderCalls: number;
+      backpressureStaticCompositions: number;
+      completedTiles: number;
+      distinctShimmerFrames: number;
+      distinctSpinnerPhases: number;
+      finalRenderCalls: number;
+      inputHandled: boolean;
+      labelCalls: number;
+      maxAnimationGapMs: number;
+      quitHandled: boolean;
+      renderCallsBeforeAnimation: number;
+      resizeHandled: boolean;
+      resumedAtClockPhase: boolean;
+      staticCompositionsAfterAnimation: number;
+      staticCompositionsBeforeAnimation: number;
+      zoomHandled: boolean;
+    };
+    expect(result).toMatchObject({
+      backpressureFrameEvents: 0,
+      inputHandled: true,
+      labelCalls: 0,
+      quitHandled: true,
+      resizeHandled: true,
+      resumedAtClockPhase: true,
+      zoomHandled: true,
+    });
+    expect(result.animationFrameCount).toBeGreaterThanOrEqual(8);
+    expect(result.distinctSpinnerPhases).toBeGreaterThanOrEqual(8);
+    expect(result.distinctShimmerFrames).toBeGreaterThanOrEqual(8);
+    expect(result.maxAnimationGapMs).toBeLessThanOrEqual(250);
+    expect(result.renderCallsBeforeAnimation).toBeGreaterThan(0);
+    expect(result.finalRenderCalls).toBe(result.renderCallsBeforeAnimation);
+    expect(result.staticCompositionsAfterAnimation).toBe(result.staticCompositionsBeforeAnimation);
+    expect(result.backpressureRenderCalls).toBeGreaterThan(0);
+    expect(result.completedTiles).toBe(result.backpressureRenderCalls);
+    expect(result.backpressureLabelCalls).toBeGreaterThan(0);
+    expect(result.backpressureStaticCompositions).toBeGreaterThan(1);
+  }, 15_000);
+});
+
+describe("viewer tile rendering status", () => {
+  it("does not add a status suffix for worker rendering", () => {
+    expect(formatRenderingModeStatus("workers")).toBe("");
+  });
+});

--- a/packages/cli/test/worker-smoke.ts
+++ b/packages/cli/test/worker-smoke.ts
@@ -1,0 +1,55 @@
+import { fileURLToPath } from "node:url";
+
+import { pointToTileFraction } from "@osmix/geo/tile";
+import type { Tile } from "osmix";
+
+import { createStyledTileRenderer } from "../src/tile-renderer.ts";
+
+const fixturePath = fileURLToPath(new URL("../../../fixtures/monaco.pbf", import.meta.url));
+let progressEvents = 0;
+const renderer = await createStyledTileRenderer({ onProgress: () => progressEvents++ });
+
+try {
+  let timerTicks = 0;
+  let maxTimerLagMs = 0;
+  let previousTick = performance.now();
+  const timer = setInterval(() => {
+    const now = performance.now();
+    maxTimerLagMs = Math.max(maxTimerLagMs, now - previousTick - 5);
+    previousTick = now;
+    timerTicks++;
+  }, 5);
+  try {
+    const info = await renderer.loadPbfFile(fixturePath, "worker-smoke");
+    const bbox = info.bbox;
+    const center = [(bbox[0] + bbox[2]) / 2, (bbox[1] + bbox[3]) / 2] as const;
+    const [tileX, tileY] = pointToTileFraction(center[0], center[1], 15);
+    const x = Math.floor(tileX);
+    const y = Math.floor(tileY);
+    const tiles: Tile[] = [
+      [x, y, 15],
+      [x + 1, y, 15],
+      [x, y + 1, 15],
+      [x + 1, y + 1, 15],
+    ];
+    const images = await Promise.all(tiles.map((tile) => renderer.renderTile(tile, 1)));
+    if (images.some((image) => image === null)) throw Error("A current tile was cancelled");
+    console.log(
+      JSON.stringify({
+        byteLengths: images.map((image) => image!.data.byteLength),
+        datasetId: info.id,
+        datasetNodes: info.stats.nodes,
+        hardwareConcurrency: navigator.hardwareConcurrency,
+        maxTimerLagMs,
+        mode: renderer.mode,
+        progressEvents,
+        timerTicks,
+        workerCount: renderer.workerCount,
+      }),
+    );
+  } finally {
+    clearInterval(timer);
+  }
+} finally {
+  renderer.dispose();
+}

--- a/packages/cli/tsconfig.build.json
+++ b/packages/cli/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./tsconfig.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "rootDir": "./src"
+  }
+}

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "@osmix/shared/tsconfig/base.json",
+  "exclude": ["node_modules", "dist"],
+  "include": ["scripts", "src", "test"],
+  "compilerOptions": {
+    "outDir": "./dist",
+    "resolveJsonModule": true
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -775,6 +775,34 @@ importers:
         specifier: 'catalog:'
         version: 7.0.2
 
+  packages/cli:
+    dependencies:
+      '@opentui/core':
+        specifier: ^0.4.3
+        version: 0.4.3(typescript@7.0.2)(web-tree-sitter@0.25.10)
+      '@osmix/geo':
+        specifier: workspace:*
+        version: link:../geo
+      '@osmix/shared':
+        specifier: workspace:*
+        version: link:../shared
+      '@osmix/shortbread':
+        specifier: workspace:*
+        version: link:../shortbread
+      comlink:
+        specifier: ^4.4.2
+        version: 4.4.2
+      osmix:
+        specifier: workspace:*
+        version: link:../osmix
+    devDependencies:
+      '@osmix/test-utils':
+        specifier: workspace:*
+        version: link:../test-utils
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
+
   packages/types:
     dependencies:
       dequal:
@@ -1262,6 +1290,53 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@opentui/core-darwin-arm64@0.4.3':
+    resolution: {integrity: sha512-p5+7AAxpxGuDGagyQfewKtmTFnN7THvTVY4FyKqUtJomNaHdQXPHztapNNzMx0DGWbwOUbVKzpL+yc3CZY3chQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@opentui/core-darwin-x64@0.4.3':
+    resolution: {integrity: sha512-+fh0vEUE0lwVC7RW5ijYLRlTLp5NfvCRj8SzxDVd7IL2j2ssB6YXcfIbXq2EW7UGnrejwPRXf1tgUrIXW9KmOw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@opentui/core-linux-arm64-musl@0.4.3':
+    resolution: {integrity: sha512-8p8g8/AEq/xFGpQ7XcIFKcAqjc0QwsZcv+Ll9RbCDpUA56FGH6jfLDir0KYTNTgYXJTIrBIENI9K46VuxMUMQA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@opentui/core-linux-arm64@0.4.3':
+    resolution: {integrity: sha512-gl6qA5QJy6u8Cbt7gOtHbhhfMZ4qQDb0kEwFXHcMGmbnKzz4OHoq74D6tNjyvSQB9saoC7C6C0tvn2DcJOuNog==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@opentui/core-linux-x64-musl@0.4.3':
+    resolution: {integrity: sha512-/QiFpCrpU2O7vy8QYmLIQYbvAtKDgmqcVjR7dGtqSzkiQk3ktNJoo5RozG7ueXnjung1Wp0nKldKxo2Csg/OrA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@opentui/core-linux-x64@0.4.3':
+    resolution: {integrity: sha512-dXpJitiZdYE3hq2Pvx6e9I0uPQSOcnaLLp1pDgWAHv+3kvKSHEX//9Yr/pV/Ua6qqT7p+2D/K4vXNap/NKVo2w==}
+    cpu: [x64]
+    os: [linux]
+
+  '@opentui/core-win32-arm64@0.4.3':
+    resolution: {integrity: sha512-Mx2zuOjrhm/z2SDS6RExIyjP/SnN/8QhhagxURUw0jQi/NssGSeAllu1cBAFFnhobJL5QLTE4FU4CRhUK9svgg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@opentui/core-win32-x64@0.4.3':
+    resolution: {integrity: sha512-NuoqvWKGXaYnmlqvu7Gg2lLI6yVMnS9OfWBvxp+7Q+McSgHFSTQmYBXaPpvQ8HikpQXE1nCeMPtuSG4PdZHe2w==}
+    cpu: [x64]
+    os: [win32]
+
+  '@opentui/core@0.4.3':
+    resolution: {integrity: sha512-rrJfAk13tALDqldYjhc78eWQ+aKq1iknJgffIOg3OwyZoqQo+p6gtuqyhmWvXIfQzlNUbpgpCPcxbXlhMnlaHQ==}
+    peerDependencies:
+      web-tree-sitter: 0.25.10
 
   '@oxc-project/types@0.138.0':
     resolution: {integrity: sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==}
@@ -2216,6 +2291,10 @@ packages:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
 
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
@@ -2287,6 +2366,11 @@ packages:
   buffer-image-size@0.6.4:
     resolution: {integrity: sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==}
     engines: {node: '>=4.0'}
+
+  bun-ffi-structs@0.2.4:
+    resolution: {integrity: sha512-AJzsqoVFs1KBbJbWHIYrVZLDC3NhTqqh25awRXqzoLzmBAKr5oqk6+CwuYHAekKx+VBCYVohBoKuRq40dV+TYg==}
+    peerDependencies:
+      typescript: ^5
 
   but-unzip@0.1.10:
     resolution: {integrity: sha512-hLfQ9WlUimmv/okzsRl6AYG3Ew5HNWhWgUslSR93FsDdeL0MAoQvmC/BJfs35lqEAO5t/QD7Y4vCFcPJtijt3A==}
@@ -2397,6 +2481,10 @@ packages:
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
+  diff@9.0.0:
+    resolution: {integrity: sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==}
+    engines: {node: '>=0.3.1'}
+
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
@@ -2406,6 +2494,9 @@ packages:
 
   earcut@3.2.3:
     resolution: {integrity: sha512-vnS4AVwp1KHAF13i1vp1/2D5evWy3k5u/iW/B81QVsUZtV8cv2tU0b2VNFlqvh4kYwrFMDdjPCfAmfyJW9y14Q==}
+
+  emoji-regex@10.6.0:
+    resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
 
   enhanced-resolve@5.21.6:
     resolution: {integrity: sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==}
@@ -2521,6 +2612,10 @@ packages:
 
   geokdbush@2.1.0:
     resolution: {integrity: sha512-bMc7mu+SeUxtHwRpVvZ36qnZa/x8YAGuaPNeGDxd9bxp/jYuJ5GrUirUPz6UNiT+nn/79IQ4gCNan0y4alEUxw==}
+
+  get-east-asian-width@1.6.0:
+    resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
+    engines: {node: '>=18'}
 
   get-nonce@1.0.1:
     resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
@@ -2796,6 +2891,11 @@ packages:
   maplibre-gl@5.24.0:
     resolution: {integrity: sha512-ALyFxgtd5R+65UqZ/++lOqwWcC0SNho9c27fYSyLmG7AfnAul2o46F05aDJGPbFU57wos9dgcIySHs0Xe6ia3A==}
     engines: {node: '>=16.14.0', npm: '>=8.1.0'}
+
+  marked@17.0.1:
+    resolution: {integrity: sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg==}
+    engines: {node: '>= 20'}
+    hasBin: true
 
   mdast-util-to-hast@13.2.1:
     resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
@@ -3214,12 +3314,20 @@ packages:
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
+  string-width@7.2.0:
+    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
+    engines: {node: '>=18'}
+
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
 
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
+
+  strip-ansi@7.1.2:
+    resolution: {integrity: sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==}
+    engines: {node: '>=12'}
 
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
@@ -3483,6 +3591,14 @@ packages:
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
+
+  web-tree-sitter@0.25.10:
+    resolution: {integrity: sha512-Y09sF44/13XvgVKgO2cNDw5rGk6s26MgoZPXLESvMXeefBf7i6/73eFurre0IsTW6E14Y0ArIzhUMmjoc7xyzA==}
+    peerDependencies:
+      '@types/emscripten': ^1.40.0
+    peerDependenciesMeta:
+      '@types/emscripten':
+        optional: true
 
   webidl-conversions@8.0.1:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
@@ -4018,6 +4134,50 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
+
+  '@opentui/core-darwin-arm64@0.4.3':
+    optional: true
+
+  '@opentui/core-darwin-x64@0.4.3':
+    optional: true
+
+  '@opentui/core-linux-arm64-musl@0.4.3':
+    optional: true
+
+  '@opentui/core-linux-arm64@0.4.3':
+    optional: true
+
+  '@opentui/core-linux-x64-musl@0.4.3':
+    optional: true
+
+  '@opentui/core-linux-x64@0.4.3':
+    optional: true
+
+  '@opentui/core-win32-arm64@0.4.3':
+    optional: true
+
+  '@opentui/core-win32-x64@0.4.3':
+    optional: true
+
+  '@opentui/core@0.4.3(typescript@7.0.2)(web-tree-sitter@0.25.10)':
+    dependencies:
+      bun-ffi-structs: 0.2.4(typescript@7.0.2)
+      diff: 9.0.0
+      marked: 17.0.1
+      string-width: 7.2.0
+      strip-ansi: 7.1.2
+      web-tree-sitter: 0.25.10
+    optionalDependencies:
+      '@opentui/core-darwin-arm64': 0.4.3
+      '@opentui/core-darwin-x64': 0.4.3
+      '@opentui/core-linux-arm64': 0.4.3
+      '@opentui/core-linux-arm64-musl': 0.4.3
+      '@opentui/core-linux-x64': 0.4.3
+      '@opentui/core-linux-x64-musl': 0.4.3
+      '@opentui/core-win32-arm64': 0.4.3
+      '@opentui/core-win32-x64': 0.4.3
+    transitivePeerDependencies:
+      - typescript
 
   '@oxc-project/types@0.138.0': {}
 
@@ -4702,6 +4862,8 @@ snapshots:
 
   ansi-regex@5.0.1: {}
 
+  ansi-regex@6.2.2: {}
+
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
@@ -4769,6 +4931,10 @@ snapshots:
     dependencies:
       '@types/node': 24.13.2
     optional: true
+
+  bun-ffi-structs@0.2.4(typescript@7.0.2):
+    dependencies:
+      typescript: 7.0.2
 
   but-unzip@0.1.10: {}
 
@@ -4883,6 +5049,8 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
+  diff@9.0.0: {}
+
   dir-glob@3.0.1:
     dependencies:
       path-type: 4.0.0
@@ -4890,6 +5058,8 @@ snapshots:
   dom-accessibility-api@0.5.16: {}
 
   earcut@3.2.3: {}
+
+  emoji-regex@10.6.0: {}
 
   enhanced-resolve@5.21.6:
     dependencies:
@@ -5025,6 +5195,8 @@ snapshots:
   geokdbush@2.1.0:
     dependencies:
       tinyqueue: 3.0.0
+
+  get-east-asian-width@1.6.0: {}
 
   get-nonce@1.0.1: {}
 
@@ -5287,6 +5459,8 @@ snapshots:
       potpack: 2.1.0
       quickselect: 3.0.0
       tinyqueue: 3.0.0
+
+  marked@17.0.1: {}
 
   mdast-util-to-hast@13.2.1:
     dependencies:
@@ -5696,6 +5870,12 @@ snapshots:
 
   std-env@4.1.0: {}
 
+  string-width@7.2.0:
+    dependencies:
+      emoji-regex: 10.6.0
+      get-east-asian-width: 1.6.0
+      strip-ansi: 7.1.2
+
   stringify-entities@4.0.4:
     dependencies:
       character-entities-html4: 2.1.0
@@ -5704,6 +5884,10 @@ snapshots:
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
+
+  strip-ansi@7.1.2:
+    dependencies:
+      ansi-regex: 6.2.2
 
   strip-bom@3.0.0: {}
 
@@ -5930,6 +6114,8 @@ snapshots:
 
   web-streams-polyfill@3.3.3:
     optional: true
+
+  web-tree-sitter@0.25.10: {}
 
   webidl-conversions@8.0.1:
     optional: true


### PR DESCRIPTION
## Summary

- add the `@osmix/cli` package with the `osmix` terminal map viewer
- render styled, labeled OSM PBF maps with worker-backed progressive loading
- add standalone Bun executable builds and local executable smoke coverage
- add CI and GitHub Release artifact publication for supported targets

## CI and history

This PR is rebased onto `main` after #212 and contains one CLI commit. The general verification job installs Bun 1.3.14 because the CLI worker and animation tests intentionally spawn Bun subprocesses. The worker concurrency smoke uses the tracked Monaco PBF so it runs consistently in clean CI checkouts.

## Verification

- `CI=true pnpm run test:packages` - 81 files passed, 1 skipped; 689 tests passed, 3 skipped
- `pnpm run verify:workspace -- @osmix/cli` - 85 tests passed
- `pnpm --filter @osmix/cli run test:executable`
- `pnpm run check:deps`
- `pnpm exec changeset status --since=origin/main` reports only `@osmix/cli`
- `pnpm exec oxfmt . --check`
