### PR TITLE
Remove the SharedArrayBuffer shim requirement

### DIFF
--- a/.changeset/safe-buffers-fallback.md
+++ b/.changeset/safe-buffers-fallback.md
@@ -1,0 +1,11 @@
+---
+"@osmix/core": patch
+"@osmix/geojson": patch
+"@osmix/router": patch
+"@osmix/shapefile": patch
+"@osmix/shared": patch
+"osmix": patch
+---
+
+Allow Osmix to use its ArrayBuffer fallback when SharedArrayBuffer is unavailable, so browser
+applications no longer need to install a global SharedArrayBuffer shim.

--- a/packages/core/src/typed-arrays.ts
+++ b/packages/core/src/typed-arrays.ts
@@ -7,6 +7,8 @@
  * @module
  */
 
+import { isSharedArrayBuffer } from "@osmix/shared/backing-buffers";
+
 /**
  * Use SharedArrayBuffer if the runtime supports it, otherwise fall back to ArrayBuffer.
  * SharedArrayBuffer enables zero-copy transfer between workers.
@@ -103,7 +105,7 @@ export class ResizeableTypedArray<TA extends TypedArray> {
   static from<TA extends TypedArray>(ArrayType: TypedArrayConstructor<TA>, buffer: BufferType) {
     const rta = new ResizeableTypedArray<TA>(
       ArrayType,
-      buffer instanceof SharedArrayBuffer ? SharedArrayBuffer : ArrayBuffer,
+      isSharedArrayBuffer(buffer) ? SharedArrayBuffer : ArrayBuffer,
     );
     rta.buffer = buffer;
     rta.array = new ArrayType(buffer);
@@ -156,7 +158,7 @@ export class ResizeableTypedArray<TA extends TypedArray> {
       this.array = newArray;
     } else {
       // Can grow/resize the existing buffer in place
-      if (this.buffer instanceof SharedArrayBuffer && this.buffer.growable) {
+      if (isSharedArrayBuffer(this.buffer) && this.buffer.growable) {
         this.buffer.grow(this.bufferSize);
       } else if (this.buffer instanceof ArrayBuffer && this.buffer.resizable) {
         this.buffer.resize(this.bufferSize);
@@ -226,7 +228,7 @@ export class ResizeableTypedArray<TA extends TypedArray> {
    * Buffer becomes fixed-length after compacting.
    */
   compact() {
-    if (this.buffer instanceof SharedArrayBuffer) {
+    if (isSharedArrayBuffer(this.buffer)) {
       // SharedArrayBuffer uses slice() to create a new fixed-size buffer
       this.buffer = this.buffer.slice(0, this.length * this.ArrayType.BYTES_PER_ELEMENT);
     } else {

--- a/packages/core/test/no-shared-array-buffer.test.ts
+++ b/packages/core/test/no-shared-array-buffer.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+describe("without SharedArrayBuffer", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.resetModules();
+  });
+
+  it("builds indexes and manages ArrayBuffer-backed typed arrays", async () => {
+    vi.stubGlobal("SharedArrayBuffer", undefined);
+    vi.resetModules();
+
+    const { BufferConstructor, ResizeableTypedArray } = await import("../src/typed-arrays.ts");
+    const { Osm } = await import("../src/osm.ts");
+
+    expect(BufferConstructor).toBe(ArrayBuffer);
+
+    const osm = new Osm({ id: "array-buffer-only" });
+    osm.nodes.addNode({ id: 1, lon: 115.2167, lat: -8.65, tags: { place: "city" } });
+    osm.nodes.addNode({ id: 2, lon: 115.22, lat: -8.66 });
+    osm.ways.addWay({ id: 1, refs: [1, 2], tags: { highway: "residential" } });
+    osm.buildIndexes();
+
+    expect(osm.isReady()).toBe(true);
+    expect(osm.nodes.getById(1)?.tags?.["place"]).toBe("city");
+
+    const restored = ResizeableTypedArray.from(Uint8Array, new ArrayBuffer(4));
+    expect(restored.BC).toBe(ArrayBuffer);
+
+    const growing = new ResizeableTypedArray(Uint8Array);
+    growing.items = growing.array.length;
+    growing.push(7);
+    expect(growing.buffer).toBeInstanceOf(ArrayBuffer);
+    expect(growing.at(-1)).toBe(7);
+
+    const compacted = growing.compact();
+    expect(compacted.buffer).toBeInstanceOf(ArrayBuffer);
+    expect(compacted.length).toBe(growing.length);
+  });
+});

--- a/packages/geojson/src/utils.ts
+++ b/packages/geojson/src/utils.ts
@@ -3,6 +3,8 @@
  * @module
  */
 
+import { isSharedArrayBuffer } from "@osmix/shared/backing-buffers";
+
 import type { ImportableGeoJSON, ReadOsmDataTypes } from "./types.ts";
 
 /**
@@ -42,7 +44,7 @@ export async function readDataAsGeoJSON(data: ReadOsmDataTypes): Promise<Importa
     }
     return JSON.parse(result) as ImportableGeoJSON;
   }
-  if (data instanceof ArrayBuffer || data instanceof SharedArrayBuffer) {
+  if (data instanceof ArrayBuffer || isSharedArrayBuffer(data)) {
     const decoder = new TextDecoder();
     const text = decoder.decode(new Uint8Array(data));
     return JSON.parse(text) as ImportableGeoJSON;

--- a/packages/geojson/test/no-shared-array-buffer.test.ts
+++ b/packages/geojson/test/no-shared-array-buffer.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+describe("GeoJSON without SharedArrayBuffer", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.resetModules();
+  });
+
+  it("reads binary GeoJSON into ArrayBuffer-backed indexes", async () => {
+    vi.stubGlobal("SharedArrayBuffer", undefined);
+    vi.resetModules();
+
+    const { fromGeoJSON } = await import("../src/osm-from-geojson.ts");
+    const input = new TextEncoder().encode(
+      JSON.stringify({
+        type: "FeatureCollection",
+        features: [
+          {
+            type: "Feature",
+            geometry: { type: "Point", coordinates: [115.2167, -8.65] },
+            properties: { name: "Denpasar" },
+          },
+        ],
+      }),
+    ).buffer;
+
+    const osm = await fromGeoJSON(input);
+
+    expect(osm.nodes.getById(-1)?.tags?.["name"]).toBe("Denpasar");
+  });
+});

--- a/packages/osmix/src/remote.ts
+++ b/packages/osmix/src/remote.ts
@@ -20,7 +20,7 @@ import type {
   RouteResult,
   RoutingGraphTransferables,
 } from "@osmix/router";
-import { inspectBackingBuffers } from "@osmix/shared/backing-buffers";
+import { inspectBackingBuffers, isSharedArrayBuffer } from "@osmix/shared/backing-buffers";
 import type { Progress } from "@osmix/shared/progress";
 import { streamToBytes } from "@osmix/shared/stream-to-bytes";
 import type { LonLat, OsmEntityType, Tile } from "@osmix/types";
@@ -702,7 +702,7 @@ export class OsmixRemote<T extends OsmixWorker = OsmixWorker> {
 
   private async getTransferableData(data: ArrayBufferLike | ReadableStream | Uint8Array | File) {
     if (data instanceof ArrayBuffer) return data;
-    if (typeof SharedArrayBuffer !== "undefined" && data instanceof SharedArrayBuffer) return data;
+    if (isSharedArrayBuffer(data)) return data;
     if (data instanceof Uint8Array) {
       if (data.byteOffset === 0 && data.byteLength === data.buffer.byteLength) {
         return data.buffer;

--- a/packages/osmix/src/utils.ts
+++ b/packages/osmix/src/utils.ts
@@ -6,14 +6,11 @@
  * @module
  */
 
+import { isSharedArrayBuffer } from "@osmix/shared/backing-buffers";
 import { transfer as comlinkTransfer } from "comlink";
 
 /** Types that can be transferred between workers without copying. */
 export type Transferables = ArrayBufferLike | ReadableStream;
-
-function isSharedArrayBuffer(value: unknown): value is SharedArrayBuffer {
-  return typeof SharedArrayBuffer !== "undefined" && value instanceof SharedArrayBuffer;
-}
 
 /**
  * Recursively collect all transferable values from a nested object.

--- a/packages/router/src/graph.ts
+++ b/packages/router/src/graph.ts
@@ -385,7 +385,5 @@ export function getTransferableBuffers(t: RoutingGraphTransferables): ArrayBuffe
     t.intersectionBits,
   ];
   // Only ArrayBuffers need to be transferred; SharedArrayBuffers are shared automatically
-  return buffers.filter(
-    (b): b is ArrayBuffer => b instanceof ArrayBuffer && !(b instanceof SharedArrayBuffer),
-  );
+  return buffers.filter((b): b is ArrayBuffer => b instanceof ArrayBuffer);
 }

--- a/packages/router/test/no-shared-array-buffer.test.ts
+++ b/packages/router/test/no-shared-array-buffer.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+describe("router transfers without SharedArrayBuffer", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.resetModules();
+  });
+
+  it("returns every ArrayBuffer in the transfer list", async () => {
+    vi.stubGlobal("SharedArrayBuffer", undefined);
+    vi.resetModules();
+
+    const { getTransferableBuffers } = await import("../src/graph.ts");
+    const createBuffer = () => new ArrayBuffer(4);
+    const transferables = {
+      nodeCount: 0,
+      edgeCount: 0,
+      edgeOffsets: createBuffer(),
+      edgeTargets: createBuffer(),
+      edgeWayIndexes: createBuffer(),
+      edgeDistances: createBuffer(),
+      edgeTimes: createBuffer(),
+      routableBits: createBuffer(),
+      intersectionBits: createBuffer(),
+    };
+
+    expect(getTransferableBuffers(transferables)).toEqual([
+      transferables.edgeOffsets,
+      transferables.edgeTargets,
+      transferables.edgeWayIndexes,
+      transferables.edgeDistances,
+      transferables.edgeTimes,
+      transferables.routableBits,
+      transferables.intersectionBits,
+    ]);
+  });
+});

--- a/packages/shapefile/src/utils.ts
+++ b/packages/shapefile/src/utils.ts
@@ -4,6 +4,7 @@
  * Utility functions for Shapefile data handling.
  * @module
  */
+import { isSharedArrayBuffer } from "@osmix/shared/backing-buffers";
 import type { FeatureCollection } from "geojson";
 import shp from "shpjs";
 
@@ -37,7 +38,7 @@ export async function parseShapefile(
   // Convert ReadableStream to ArrayBuffer
   if (data instanceof ReadableStream) {
     input = await streamToArrayBuffer(data);
-  } else if (data instanceof SharedArrayBuffer) {
+  } else if (isSharedArrayBuffer(data)) {
     // shpjs expects ArrayBuffer, not SharedArrayBuffer
     const copy = new ArrayBuffer(data.byteLength);
     new Uint8Array(copy).set(new Uint8Array(data));

--- a/packages/shapefile/test/no-shared-array-buffer.test.ts
+++ b/packages/shapefile/test/no-shared-array-buffer.test.ts
@@ -1,0 +1,37 @@
+import type { FeatureCollection, Point } from "geojson";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { parseMock } = vi.hoisted(() => ({ parseMock: vi.fn() }));
+
+vi.mock("shpjs", () => ({ default: parseMock }));
+
+describe("Shapefile import without SharedArrayBuffer", () => {
+  afterEach(() => {
+    parseMock.mockReset();
+    vi.unstubAllGlobals();
+    vi.resetModules();
+  });
+
+  it("passes ArrayBuffer input to shpjs and builds indexes", async () => {
+    const collection: FeatureCollection<Point> = {
+      type: "FeatureCollection",
+      features: [
+        {
+          type: "Feature",
+          geometry: { type: "Point", coordinates: [115.2167, -8.65] },
+          properties: { name: "Denpasar" },
+        },
+      ],
+    };
+    parseMock.mockResolvedValue(collection);
+    vi.stubGlobal("SharedArrayBuffer", undefined);
+    vi.resetModules();
+
+    const { fromShapefile } = await import("../src/osm-from-shapefile.ts");
+    const input = new ArrayBuffer(8);
+    const osm = await fromShapefile(input, {}, () => {});
+
+    expect(parseMock).toHaveBeenCalledWith(input);
+    expect(osm.nodes.getById(-1)?.tags?.["name"]).toBe("Denpasar");
+  });
+});

--- a/packages/shared/README.md
+++ b/packages/shared/README.md
@@ -29,7 +29,7 @@ pnpm add @osmix/shared
 | Module                                | Description                                              |
 | ------------------------------------- | -------------------------------------------------------- |
 | `@osmix/shared/assert`                | Tiny invariant helpers that throw typed errors.          |
-| `@osmix/shared/backing-buffers`       | Inspect shared, unique, and referenced backing bytes.    |
+| `@osmix/shared/backing-buffers`       | Detect and inspect shared and ordinary backing buffers.  |
 | `@osmix/shared/bbox-intersects`       | Bounding-box intersection + containment checks.          |
 | `@osmix/shared/bytes-to-stream`       | Create a ReadableStream from a Uint8Array.               |
 | `@osmix/shared/coordinates`           | Utilities for coordinate precision (7 decimal places).   |

--- a/packages/shared/src/backing-buffers.test.ts
+++ b/packages/shared/src/backing-buffers.test.ts
@@ -1,6 +1,25 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { inspectBackingBuffers } from "./backing-buffers.ts";
+import { inspectBackingBuffers, isSharedArrayBuffer } from "./backing-buffers.ts";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("isSharedArrayBuffer", () => {
+  it("detects shared buffers when the constructor is available", () => {
+    if (typeof SharedArrayBuffer === "undefined") return;
+
+    expect(isSharedArrayBuffer(new SharedArrayBuffer(8))).toBe(true);
+    expect(isSharedArrayBuffer(new ArrayBuffer(8))).toBe(false);
+  });
+
+  it("returns false when the constructor is unavailable", () => {
+    vi.stubGlobal("SharedArrayBuffer", undefined);
+
+    expect(isSharedArrayBuffer(new ArrayBuffer(8))).toBe(false);
+  });
+});
 
 describe("inspectBackingBuffers", () => {
   it("distinguishes references, identities, shared buffers, and bytes", () => {

--- a/packages/shared/src/backing-buffers.ts
+++ b/packages/shared/src/backing-buffers.ts
@@ -15,11 +15,13 @@ export interface BackingBufferInspection {
 
 type BackingBuffer = ArrayBuffer | SharedArrayBuffer;
 
+/** Check for SharedArrayBuffer without assuming the constructor exists in this runtime. */
+export function isSharedArrayBuffer(value: unknown): value is SharedArrayBuffer {
+  return typeof SharedArrayBuffer !== "undefined" && value instanceof SharedArrayBuffer;
+}
+
 function isBackingBuffer(value: unknown): value is BackingBuffer {
-  return (
-    value instanceof ArrayBuffer ||
-    (typeof SharedArrayBuffer !== "undefined" && value instanceof SharedArrayBuffer)
-  );
+  return value instanceof ArrayBuffer || isSharedArrayBuffer(value);
 }
 
 /** Inspect backing-buffer identity and byte usage in an arbitrarily nested value. */
@@ -69,7 +71,7 @@ export function inspectBackingBuffers(value: unknown): BackingBufferInspection {
   let uniqueBytes = 0;
   for (const buffer of uniqueBuffers) {
     uniqueBytes += buffer.byteLength;
-    if (typeof SharedArrayBuffer !== "undefined" && buffer instanceof SharedArrayBuffer) shared++;
+    if (isSharedArrayBuffer(buffer)) shared++;
     else arrayBuffers++;
   }
   return {


### PR DESCRIPTION
## Summary
- Centralize safe SharedArrayBuffer detection across buffer handling and worker transfers
- Allow ArrayBuffer-only runtimes to load, index, import, and transfer Osmix data
- Add release notes and regression coverage for environments without SharedArrayBuffer

## Testing
- Added unit tests covering core typed arrays, GeoJSON, router transfers, shapefile imports, and shared-buffer detection